### PR TITLE
Add Receitas x Despesas comparison chart to dashboard (Chart.js)

### DIFF
--- a/src/css/dashboard.css
+++ b/src/css/dashboard.css
@@ -318,6 +318,33 @@
   border-top: 1px solid var(--color-border);
 }
 .parc-compra-desc  { flex: 1; color: var(--color-text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ══════════════════════════════════════════════════════════════
+   GRÁFICO RECEITAS X DESPESAS (RF-017)
+   ══════════════════════════════════════════════════════════════ */
+.rec-chart-card {
+  margin-top: var(--space-5);
+  padding: var(--space-4);
+}
+.rec-chart-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.rec-chart-header h3 {
+  margin: 0;
+  font-size: var(--font-size-base);
+}
+.rec-chart-sub {
+  font-size: .72rem;
+  color: var(--color-text-muted);
+}
+.rec-chart-wrap {
+  position: relative;
+  min-height: 260px;
+}
 .parc-compra-info  { color: var(--color-text-muted); white-space: nowrap; }
 .parc-compra-valor { font-weight: 700; color: var(--color-text); white-space: nowrap; }
 

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -121,6 +121,16 @@
       <div class="categorias-grid" id="receitas-grid">
         <p class="empty-state">Carregando receitas...</p>
       </div>
+
+      <div class="card rec-chart-card">
+        <div class="rec-chart-header">
+          <h3>📊 Receitas x Despesas por categoria</h3>
+          <span class="rec-chart-sub">Comparativo do mês selecionado</span>
+        </div>
+        <div class="rec-chart-wrap">
+          <canvas id="rec-vs-desp-chart" height="120"></canvas>
+        </div>
+      </div>
     </section>
 
     <!-- ═══ SEÇÃO: DESPESAS ═══ -->
@@ -143,6 +153,7 @@
   <!-- Firebase SDK (versão modular) -->
   <!-- TODO: Substituir pelos scripts do seu projeto Firebase -->
   <!-- <script type="module" src="js/config/firebase.js"></script> -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
   <script type="module" src="js/app.js"></script>
 
 </body>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -116,7 +116,8 @@ function iniciarListeners() {
     renderizarDashboardReceitas(
       estadoApp.categoriasReceita,
       estadoApp.receitas,
-      estadoApp.despesas.filter(d => d.tipo !== 'projecao').reduce((s, d) => s + (d.valor ?? 0), 0),
+      estadoApp.categorias,
+      estadoApp.despesas,
     );
   });
 
@@ -133,7 +134,8 @@ function iniciarListeners() {
     renderizarDashboardReceitas(
       estadoApp.categoriasReceita,
       estadoApp.receitas,
-      estadoApp.despesas.filter(d => d.tipo !== 'projecao').reduce((s, d) => s + (d.valor ?? 0), 0),
+      estadoApp.categorias,
+      estadoApp.despesas,
     );
   });
 }
@@ -147,7 +149,8 @@ function iniciarListenerCategoriasReceita(grupoId) {
     renderizarDashboardReceitas(
       estadoApp.categoriasReceita,
       estadoApp.receitas,
-      estadoApp.despesas.filter(d => d.tipo !== 'projecao').reduce((s, d) => s + (d.valor ?? 0), 0),
+      estadoApp.categorias,
+      estadoApp.despesas,
     );
   });
 }

--- a/src/js/controllers/receitas-dashboard.js
+++ b/src/js/controllers/receitas-dashboard.js
@@ -6,13 +6,18 @@
 import { formatarMoeda } from '../utils/formatters.js';
 import { definirTexto } from '../utils/helpers.js';
 
+let _chartRecVsDesp = null;
+
 /**
  * Renderiza o painel de receitas no dashboard.
  * @param {Array} categoriasReceita  — categorias do tipo 'receita'
  * @param {Array} receitas           — receitas do mês
- * @param {number} totalDespesas     — total gasto no mês (para calcular saldo)
+ * @param {Array} categoriasDespesa  — categorias do tipo 'despesa'
+ * @param {Array} despesas           — despesas do mês
  */
-export function renderizarDashboardReceitas(categoriasReceita, receitas, totalDespesas = 0) {
+export function renderizarDashboardReceitas(categoriasReceita, receitas, categoriasDespesa = [], despesas = []) {
+  const despesasReais = despesas.filter((d) => d.tipo !== 'projecao');
+  const totalDespesas = despesasReais.reduce((s, d) => s + (d.valor ?? 0), 0);
   const totalReceitas = receitas.reduce((s, r) => s + (r.valor ?? 0), 0);
   const saldo         = totalReceitas - totalDespesas;
 
@@ -62,4 +67,65 @@ export function renderizarDashboardReceitas(categoriasReceita, receitas, totalDe
       </div>
     `;
   }).join('');
+
+  renderizarGraficoReceitasDespesas(categoriasReceita, receitas, categoriasDespesa, despesasReais);
+}
+
+function renderizarGraficoReceitasDespesas(categoriasReceita, receitas, categoriasDespesa, despesas) {
+  const canvas = document.getElementById('rec-vs-desp-chart');
+  if (!canvas || typeof Chart === 'undefined') return;
+  if (_chartRecVsDesp) {
+    _chartRecVsDesp.destroy();
+    _chartRecVsDesp = null;
+  }
+
+  const mapNomeRec = Object.fromEntries(categoriasReceita.map((c) => [c.id, c.nome]));
+  const mapNomeDesp = Object.fromEntries(categoriasDespesa.map((c) => [c.id, c.nome]));
+  const recPorNome = new Map();
+  const despPorNome = new Map();
+
+  receitas.forEach((r) => {
+    const nome = mapNomeRec[r.categoriaId] ?? 'Outras Receitas';
+    recPorNome.set(nome, (recPorNome.get(nome) ?? 0) + (r.valor ?? 0));
+  });
+  despesas.forEach((d) => {
+    const nome = mapNomeDesp[d.categoriaId] ?? 'Outras Despesas';
+    despPorNome.set(nome, (despPorNome.get(nome) ?? 0) + (d.valor ?? 0));
+  });
+
+  const labels = Array.from(new Set([...recPorNome.keys(), ...despPorNome.keys()])).slice(0, 8);
+  if (!labels.length) return;
+
+  _chartRecVsDesp = new Chart(canvas, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Receitas',
+          data: labels.map((l) => recPorNome.get(l) ?? 0),
+          backgroundColor: 'rgba(46, 125, 50, 0.75)',
+          borderColor: '#2e7d32',
+          borderWidth: 1,
+        },
+        {
+          label: 'Despesas',
+          data: labels.map((l) => despPorNome.get(l) ?? 0),
+          backgroundColor: 'rgba(198, 40, 40, 0.72)',
+          borderColor: '#c62828',
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { position: 'bottom' },
+      },
+      scales: {
+        y: { beginAtZero: true },
+      },
+    },
+  });
 }


### PR DESCRIPTION
### Motivation
- Provide a visual comparison of revenues vs expenses by category on the dashboard to help users understand category-level balance for the selected month. 
- Surface the chart in the Receitas section while keeping totals/saldo accurate by excluding projection-type expenses.
- Reuse existing category and transaction data already loaded by listeners so the chart updates in real time with the dashboard.

### Description
- Added HTML for a chart card and `<canvas id="rec-vs-desp-chart">` in `src/dashboard.html` and included `chart.js` via CDN. 
- Added CSS rules (`.rec-chart-card`, `.rec-chart-header`, `.rec-chart-wrap`, etc.) in `src/css/dashboard.css` to style the new chart block. 
- Updated `src/js/app.js` to pass `categorias` and `despesas` into `renderizarDashboardReceitas` from listeners instead of a precomputed total, and adjusted category listener wiring accordingly. 
- Implemented `src/js/controllers/receitas-dashboard.js` to: compute totals (excluding `tipo === 'projecao'`), render the receitas category grid, and create/destroy a Chart.js bar chart that shows receipts vs expenses per category (limits labels to 8, builds datasets, responsive options). 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c574cf73b4833297dcc2e57f684242)