### PR TITLE
Adicionar gráfico Receitas×Despesas ao dashboard e registrar bug RF-014

### DIFF
--- a/docs/bugs/BUG_RF-014_divergencia_total_fatura_importacao_marco_2026.md
+++ b/docs/bugs/BUG_RF-014_divergencia_total_fatura_importacao_marco_2026.md
@@ -1,0 +1,126 @@
+# [BUG] RF-014/NRF-002.1 — Divergência entre total da fatura oficial e total processado na aplicação (Março/2026)
+
+## Status
+- **Severidade:** Alta
+- **Prioridade sugerida:** P1
+- **Tipo:** Bug funcional (importação e fechamento de fatura)
+- **Módulos afetados:** `importar.html` / `src/js/pages/importar.js` / `fatura.html`
+- **Labels sugeridas (GitHub):** `bug`, `rf-014`, `nrf-002`, `nrf-006`, `alta-prioridade`
+- **Milestone sugerida:** `RF-014 / Fatura Cartão`
+- **Issue GitHub:** `PENDENTE_ABERTURA` (abrir em `/issues/new` com este conteúdo)
+
+---
+
+## Contexto
+
+Ao importar a fatura oficial (`Fatura2026-04-05 (1)`) para o ciclo de **Março/2026**, o total e a composição de lançamentos na aplicação (`fatura-cartão-de-crédito-2026-03`) não batem com o extrato da operadora.
+
+O problema é recorrente e já foi observado com diferença entre:
+1. **Registros processados** pela aplicação (lista exportada/visualizada na fatura); e
+2. **Extrato oficial** do cartão para o mesmo ciclo.
+
+---
+
+## Evidências principais recebidas
+
+### 1) Registros processados pela aplicação (amostra recebida)
+- Contém principalmente lançamentos com data de março/2026
+- Mostra divisão por responsável (Ana / Luigi / Conjunta 50/50)
+- Inclui `Parcela de Refinanciamento com Juros` (`01/02`) no valor de `10.366,26`
+- Não apresenta diversos itens parcelados históricos exibidos no extrato oficial
+
+### 2) Extrato oficial da operadora (Março/2026)
+- Contém vários itens parcelados com **data de compra antiga** (2025 e início de 2026) cobrados no ciclo de março
+- Contém também lançamentos negativos (estornos/créditos), ex:
+  - `MERCADOLIVRE*22PRODUTOS -R$ 24,99`
+  - `IFD*HNT COMERCIO HORTI -R$ 72,67`
+- Contém linhas financeiras (`Pagamento de fatura`, `Credito de Refinanciamento...`) além de compras
+
+---
+
+## Hipótese técnica (causa provável)
+
+### A) Créditos/estornos do cartão são descartados no modo `cartao`
+No fluxo de importação, ao aplicar tipo `cartao`, linhas com `isCredito` viram erro e não são importadas:
+
+```js
+if (tipo === 'cartao') {
+  _linhas.forEach((l) => { if (l.isCredito && !l.erro) l.erro = 'Crédito/estorno — não importado'; });
+}
+```
+
+Isso pode causar divergência com o total oficial da fatura quando há estornos no ciclo.
+
+### B) Linhas financeiras são removidas por regex antes do preview/import
+Há exclusão explícita de linhas como `pagamento de fatura` e `credito de refinanciamento`:
+
+```js
+if (/pagamento de fatura|inclusao de pagamento|inclusão de pagamento|parcela de fatura rotativo|credito de refinanciamento/i.test(estabLow)) continue;
+```
+
+Dependendo da regra de negócio de conferência adotada, a exclusão pode ser correta para “compras”, mas não para reconciliação de total bruto da fatura.
+
+### C) Reconciliação/deduplicação pode ocultar parcelas esperadas
+O fluxo marca duplicatas e substituições de projeção antes da importação final. Em cenário de projeções pré-existentes, parte dos lançamentos pode não entrar como novo registro (fica desmarcado no preview por padrão), afetando a percepção de total processado.
+
+---
+
+## Passos para reproduzir (proposto)
+
+1. Acessar `importar.html` com um grupo que já possua projeções/parcelamentos.
+2. Importar o arquivo oficial `Fatura2026-04-05 (1)` no tipo `cartao`.
+3. Selecionar mês de fatura `2026-03`.
+4. Concluir importação padrão (sem marcar manualmente linhas com erro/duplicadas).
+5. Abrir `fatura.html` no período março/2026 e comparar:
+   - total da fatura no app
+   - total do extrato oficial
+   - contagem de linhas por tipo (avista/parcelada/estorno).
+
+---
+
+## Resultado esperado
+
+- O app deve permitir uma conferência rastreável do total oficial, com clareza de quais linhas foram:
+  - importadas como despesas;
+  - ignoradas por regra (pagamento/crédito/refinanciamento);
+  - tratadas como estorno;
+  - marcadas como duplicadas/reconciliadas.
+
+---
+
+## Resultado obtido
+
+- Persistem diferenças entre total da fatura oficial e total processado.
+- Usuário não consegue reconciliar facilmente “o que entrou vs o que foi ignorado” no fluxo atual.
+
+---
+
+## Impacto
+
+- Reduz confiança no fechamento da fatura.
+- Pode gerar decisões financeiras incorretas por divergência de total.
+- Aumenta esforço manual de auditoria linha a linha.
+
+---
+
+## Recomendação de correção (para agente implementador)
+
+1. Adicionar modo de importação com **reconciliação contábil**:
+   - `compras` (comportamento atual) e
+   - `conferencia_fatura` (inclui estornos como ajuste negativo no resumo).
+2. Exibir relatório pós-import com contadores:
+   - importadas,
+   - ignoradas por regra financeira,
+   - estornos/créditos,
+   - duplicadas,
+   - reconciliadas por projeção.
+3. Persistir um artefato de auditoria por importação (snapshot resumido).
+4. Garantir export de conferência para facilitar comparação com operadora.
+
+---
+
+## Referências de código
+
+- `src/js/pages/importar.js` — aplicação de tipo/cartão e descarte de créditos.
+- `src/js/pages/importar.js` — filtro regex de linhas financeiras.
+- `src/js/pages/importar.js` — deduplicação/reconciliação no preview.

--- a/src/css/dashboard.css
+++ b/src/css/dashboard.css
@@ -318,6 +318,33 @@
   border-top: 1px solid var(--color-border);
 }
 .parc-compra-desc  { flex: 1; color: var(--color-text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ══════════════════════════════════════════════════════════════
+   GRÁFICO RECEITAS X DESPESAS (RF-017)
+   ══════════════════════════════════════════════════════════════ */
+.rec-chart-card {
+  margin-top: var(--space-5);
+  padding: var(--space-4);
+}
+.rec-chart-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.rec-chart-header h3 {
+  margin: 0;
+  font-size: var(--font-size-base);
+}
+.rec-chart-sub {
+  font-size: .72rem;
+  color: var(--color-text-muted);
+}
+.rec-chart-wrap {
+  position: relative;
+  min-height: 260px;
+}
 .parc-compra-info  { color: var(--color-text-muted); white-space: nowrap; }
 .parc-compra-valor { font-weight: 700; color: var(--color-text); white-space: nowrap; }
 

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -121,6 +121,16 @@
       <div class="categorias-grid" id="receitas-grid">
         <p class="empty-state">Carregando receitas...</p>
       </div>
+
+      <div class="card rec-chart-card">
+        <div class="rec-chart-header">
+          <h3>📊 Receitas x Despesas por categoria</h3>
+          <span class="rec-chart-sub">Comparativo do mês selecionado</span>
+        </div>
+        <div class="rec-chart-wrap">
+          <canvas id="rec-vs-desp-chart" height="120"></canvas>
+        </div>
+      </div>
     </section>
 
     <!-- ═══ SEÇÃO: DESPESAS ═══ -->
@@ -143,6 +153,7 @@
   <!-- Firebase SDK (versão modular) -->
   <!-- TODO: Substituir pelos scripts do seu projeto Firebase -->
   <!-- <script type="module" src="js/config/firebase.js"></script> -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
   <script type="module" src="js/app.js"></script>
 
 </body>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -116,7 +116,8 @@ function iniciarListeners() {
     renderizarDashboardReceitas(
       estadoApp.categoriasReceita,
       estadoApp.receitas,
-      estadoApp.despesas.filter(d => d.tipo !== 'projecao').reduce((s, d) => s + (d.valor ?? 0), 0),
+      estadoApp.categorias,
+      estadoApp.despesas,
     );
   });
 
@@ -133,7 +134,8 @@ function iniciarListeners() {
     renderizarDashboardReceitas(
       estadoApp.categoriasReceita,
       estadoApp.receitas,
-      estadoApp.despesas.filter(d => d.tipo !== 'projecao').reduce((s, d) => s + (d.valor ?? 0), 0),
+      estadoApp.categorias,
+      estadoApp.despesas,
     );
   });
 }
@@ -147,7 +149,8 @@ function iniciarListenerCategoriasReceita(grupoId) {
     renderizarDashboardReceitas(
       estadoApp.categoriasReceita,
       estadoApp.receitas,
-      estadoApp.despesas.filter(d => d.tipo !== 'projecao').reduce((s, d) => s + (d.valor ?? 0), 0),
+      estadoApp.categorias,
+      estadoApp.despesas,
     );
   });
 }

--- a/src/js/controllers/receitas-dashboard.js
+++ b/src/js/controllers/receitas-dashboard.js
@@ -6,13 +6,18 @@
 import { formatarMoeda } from '../utils/formatters.js';
 import { definirTexto } from '../utils/helpers.js';
 
+let _chartRecVsDesp = null;
+
 /**
  * Renderiza o painel de receitas no dashboard.
  * @param {Array} categoriasReceita  — categorias do tipo 'receita'
  * @param {Array} receitas           — receitas do mês
- * @param {number} totalDespesas     — total gasto no mês (para calcular saldo)
+ * @param {Array} categoriasDespesa  — categorias do tipo 'despesa'
+ * @param {Array} despesas           — despesas do mês
  */
-export function renderizarDashboardReceitas(categoriasReceita, receitas, totalDespesas = 0) {
+export function renderizarDashboardReceitas(categoriasReceita, receitas, categoriasDespesa = [], despesas = []) {
+  const despesasReais = despesas.filter((d) => d.tipo !== 'projecao');
+  const totalDespesas = despesasReais.reduce((s, d) => s + (d.valor ?? 0), 0);
   const totalReceitas = receitas.reduce((s, r) => s + (r.valor ?? 0), 0);
   const saldo         = totalReceitas - totalDespesas;
 
@@ -62,4 +67,65 @@ export function renderizarDashboardReceitas(categoriasReceita, receitas, totalDe
       </div>
     `;
   }).join('');
+
+  renderizarGraficoReceitasDespesas(categoriasReceita, receitas, categoriasDespesa, despesasReais);
+}
+
+function renderizarGraficoReceitasDespesas(categoriasReceita, receitas, categoriasDespesa, despesas) {
+  const canvas = document.getElementById('rec-vs-desp-chart');
+  if (!canvas || typeof Chart === 'undefined') return;
+  if (_chartRecVsDesp) {
+    _chartRecVsDesp.destroy();
+    _chartRecVsDesp = null;
+  }
+
+  const mapNomeRec = Object.fromEntries(categoriasReceita.map((c) => [c.id, c.nome]));
+  const mapNomeDesp = Object.fromEntries(categoriasDespesa.map((c) => [c.id, c.nome]));
+  const recPorNome = new Map();
+  const despPorNome = new Map();
+
+  receitas.forEach((r) => {
+    const nome = mapNomeRec[r.categoriaId] ?? 'Outras Receitas';
+    recPorNome.set(nome, (recPorNome.get(nome) ?? 0) + (r.valor ?? 0));
+  });
+  despesas.forEach((d) => {
+    const nome = mapNomeDesp[d.categoriaId] ?? 'Outras Despesas';
+    despPorNome.set(nome, (despPorNome.get(nome) ?? 0) + (d.valor ?? 0));
+  });
+
+  const labels = Array.from(new Set([...recPorNome.keys(), ...despPorNome.keys()])).slice(0, 8);
+  if (!labels.length) return;
+
+  _chartRecVsDesp = new Chart(canvas, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Receitas',
+          data: labels.map((l) => recPorNome.get(l) ?? 0),
+          backgroundColor: 'rgba(46, 125, 50, 0.75)',
+          borderColor: '#2e7d32',
+          borderWidth: 1,
+        },
+        {
+          label: 'Despesas',
+          data: labels.map((l) => despPorNome.get(l) ?? 0),
+          backgroundColor: 'rgba(198, 40, 40, 0.72)',
+          borderColor: '#c62828',
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { position: 'bottom' },
+      },
+      scales: {
+        y: { beginAtZero: true },
+      },
+    },
+  });
 }


### PR DESCRIPTION
### Motivation

- Expor comparação visual entre receitas e despesas por categoria no dashboard para facilitar análise mensal. 
- Corrigir fluxo de renderização para que o componente de receitas tenha acesso às categorias e despesas necessárias ao cálculo do saldo e do gráfico. 
- Registrar investigação do bug de divergência do total de fatura (RF-014) para rastreamento e ações futuras.

### Description

- Adiciona documentação do bug em `docs/bugs/BUG_RF-014_divergencia_total_fatura_importacao_marco_2026.md` com contexto, hipóteses e recomendações de correção. 
- Inclui novo card e `canvas` no `src/dashboard.html` para o gráfico "Receitas x Despesas" e adiciona import de `Chart.js`. 
- Estende `src/css/dashboard.css` com estilos do card e do wrapper do gráfico (`.rec-chart-card`, `.rec-chart-header`, `.rec-chart-wrap`, etc.). 
- Ajusta `src/js/app.js` para passar `categorias` e `despesas` ao renderer de receitas em vez de um total pré-calculado. 
- Refatora `src/js/controllers/receitas-dashboard.js` para recalcular `totalDespesas` (ignorando `tipo === 'projecao'`), renderizar o grid de receitas e implementar `renderizarGraficoReceitasDespesas` que cria/descarta um gráfico de barras `Chart` com séries de Receitas e Despesas agrupadas por categoria.

### Testing

- Não foram executados testes automatizados nesta mudança (nenhum teste automatizado adicionado ou rodado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c574cf73b4833297dcc2e57f684242)