### PR TITLE
fix: BUG-025 — fatura não carrega após import de cartão (v3.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ---
 
+## [3.9.1] - 2026-03-30
+
+### Corrigido — BUG-025: Aba "Fatura do Cartão" não carrega após importação de dados de cartão
+
+#### `src/js/pages/fatura.js` + `src/js/pages/importar.js`
+- **Problema:** `garantirContasPadrao` era chamada exclusivamente em `app.js` (carregado apenas por `dashboard.html`). Usuários que acessavam `base-dados.html` para importar e depois navegavam para `fatura.html` sem visitar o dashboard nunca tinham as contas padrão criadas. A coleção `contas` ficava vazia → `ouvirContas` retornava `[]` → seletor de cartão só exibia "— selecione —" → nenhum auto-select → página presa no estado vazio indefinidamente.
+- **Impacto secundário:** sem contas disponíveis durante o import, `contaId` ficava `undefined` em todas as transações importadas, tornando-as invisíveis na fatura mesmo após o problema principal ser corrigido.
+- **Fix `fatura.js`:** importa `garantirContasPadrao` + `CONTAS_PADRAO`; chama `await garantirContasPadrao(_grupoId, CONTAS_PADRAO).catch(() => {})` antes de `ouvirContas` — garante que `💳 Cartão de Crédito` (`tipo:'cartao'`) exista para o auto-select funcionar.
+- **Fix `importar.js`:** mesma chamada antes de montar o preview — garante que o seletor de conta esteja populado no momento do import, evitando `contaId: undefined` nas despesas importadas.
+
+---
+
 ## [3.8.0] - 2026-03-27
 
 ### Corrigido — BUG-021 + BUG-022: Ciclo de faturamento não modelado — 43 transações ausentes da fatura (R$ 7.926,93)

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -609,6 +609,48 @@ Se um estorno/crédito da fatura já havia sido importado em ciclo anterior, o c
 
 ---
 
+### BUG-025 — `garantirContasPadrao` ausente em `fatura.js` e `importar.js` — aba fatura não carrega após import
+**Severidade:** 🔴 Crítico
+**Versão introduzida:** v1.8.0 (NRF-004 — adicionou coleção `contas`)
+**Versão corrigida:** v3.9.1
+**Arquivos:** `src/js/pages/fatura.js`, `src/js/pages/importar.js`
+
+**Descrição:**
+`garantirContasPadrao` (que cria as contas padrão do grupo, incluindo `💳 Cartão de Crédito` com `tipo:'cartao'`) era chamada **apenas** em `app.js`, carregado exclusivamente por `dashboard.html`. Usuários que acessavam `base-dados.html` para importar dados e depois navegavam para `fatura.html` sem nunca ter visitado o dashboard nunca tinham as contas criadas.
+
+**Código problemático (antes):**
+```javascript
+// app.js (carregado APENAS por dashboard.html)
+garantirContasPadrao(estadoApp.perfil.grupoId, CONTAS_PADRAO).catch(() => {});
+
+// fatura.js e importar.js — garantirContasPadrao NUNCA chamada
+_unsubContas = ouvirContas(_grupoId, (contas) => {
+  // contas = [] se usuário não visitou o dashboard
+  preencherSeletorCartao();  // dropdown fica só com "— selecione —"
+});
+```
+
+**Cadeia de impacto:**
+1. Usuário registra conta → vai para `base-dados.html` sem passar pelo dashboard
+2. `garantirContasPadrao` nunca chamada → coleção `contas` vazia para o grupo
+3. Durante o import: `ouvirContas` retorna `[]` → seletor de conta vazio → `contaId: undefined` em todas as transações importadas
+4. Em `fatura.html`: `ouvirContas` retorna `[]` → `preencherSeletorCartao` não encontra conta com `tipo:'cartao'` → nenhum auto-select → `_cartaoId` nunca definido → `recarregarDespesas()` nunca chamado → página presa no estado vazio indefinidamente
+
+**Correção aplicada:**
+- `fatura.js`: importa `garantirContasPadrao` e `CONTAS_PADRAO`; chama `await garantirContasPadrao(_grupoId, CONTAS_PADRAO).catch(() => {})` antes de `ouvirContas` — garante que `💳 Cartão de Crédito` exista para o auto-select funcionar
+- `importar.js`: mesma chamada antes de carregar o preview — garante que o seletor de conta esteja populado no momento do import, evitando `contaId: undefined` nas despesas
+
+```javascript
+// fatura.js e importar.js — DEPOIS do fix
+await garantirContasPadrao(_grupoId, CONTAS_PADRAO).catch(() => {});
+_unsubContas = ouvirContas(_grupoId, (contas) => {
+  // contas agora sempre inclui as contas padrão
+  preencherSeletorCartao();  // auto-seleciona "Cartão de Crédito"
+});
+```
+
+---
+
 ## Dívida Técnica / Melhorias Pendentes
 
 Itens identificados em revisão de código que não são bugs (não quebram funcionalidade), mas representam oportunidades de melhoria de performance, manutenibilidade ou UX.

--- a/docs/GUIA_VERSIONAMENTO.md
+++ b/docs/GUIA_VERSIONAMENTO.md
@@ -66,6 +66,7 @@ Formato: `MAJOR.MINOR.PATCH` — ex: `v1.2.3`
 | v3.7.0 | 2026-03-27 | BUG-019: estornos auto-desmarcados no preview (créditos da fatura não importados) |
 | v3.8.0 | 2026-03-29 | BUG-020 + BUG-021 + BUG-022: ciclo de faturamento mesFatura não modelado |
 | v3.9.0 | 2026-03-29 | BUG-023 + BUG-024: double-counting projecao_paga + mesFatura estornos duplicados |
+| v3.9.1 | 2026-03-30 | BUG-025: fatura não carrega após import — garantirContasPadrao ausente em fatura.js/importar.js |
 
 ### Próximas Versões (Backlog)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",


### PR DESCRIPTION
## Problema

Após importar dados de cartão de crédito em `base-dados.html`, a aba **Fatura do Cartão** ficava presa no estado vazio ("Selecione um cartão para visualizar a fatura do mês.") indefinidamente — o seletor de cartão exibia apenas "— selecione —" sem nenhuma conta.

## Causa raiz

`garantirContasPadrao` era chamada **exclusivamente** em `app.js`, carregado apenas por `dashboard.html`. Usuários que iam direto para `base-dados.html` (import) → `fatura.html` sem visitar o dashboard nunca tinham as contas padrão criadas na coleção `contas`.

**Cadeia de falha:**
1. Coleção `contas` vazia → `ouvirContas` retorna `[]`
2. `preencherSeletorCartao()` não encontra conta com `tipo:'cartao'` → nenhum auto-select
3. `_cartaoId` nunca definido → `recarregarDespesas()` nunca chamado
4. Página presa no estado vazio indefinidamente

**Impacto secundário:** sem contas durante o import, `contaId` ficava `undefined` em todas as transações importadas → invisíveis na fatura mesmo após o fix principal.

## Correção

| Arquivo | Mudança |
|---|---|
| `fatura.js` | Chama `garantirContasPadrao` antes de `ouvirContas` — garante `💳 Cartão de Crédito` para auto-select |
| `importar.js` | Chama `garantirContasPadrao` antes do preview — seletor de conta populado durante import |

## Documentação

- `docs/BUGS.md`: BUG-025 registrado com cadeia de impacto completa
- `CHANGELOG.md`: seção [3.9.1] - 2026-03-30
- `docs/GUIA_VERSIONAMENTO.md`: v3.9.1 adicionado ao histórico
- `package.json`: bump `3.9.0` → `3.9.1`