### PR TITLE
fix(importar): carregar chaves de dedup de receitas também para fatura de cartão

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+### Corrigido — BUG-024 (follow-up): deduplicação de estornos em import de cartão
+
+#### `src/js/pages/importar.js`
+- **Problema residual:** mesmo após BUG-024 (v3.9.0), o fluxo `cartao` não carregava `buscarChavesDedupReceitas` durante `marcarDuplicatas()`.
+- **Impacto:** estornos/créditos (`tipoLinha='receita'`) vindos de fatura de cartão podiam não ser marcados como duplicados, impedindo propagação de `mesFatura` em reimports de ciclos futuros.
+- **Fix:** condição de carga das chaves de receita passou a incluir `_tipoExtrato === 'cartao'`.
+
 ### Melhorado — Épico A: Hierarquia e composição do dashboard
 
 #### `src/dashboard.html`

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -559,7 +559,7 @@ l.duplicado = true;  // ← faltava: l.duplicado_docId = Map.get(chave)
 ### BUG-023 — `projecao_paga` incluída no total da fatura — double-counting de parceladas reconciliadas
 **Severidade:** 🔴 Crítico
 **Versão introduzida:** v1.8.0 (NRF-005 — fatura.js)
-**Versão corrigida:** v3.9.0
+**Versão corrigida:** v3.9.0 (parcial) / v3.9.2 (completa)
 **Arquivo:** `src/js/pages/fatura.js`
 
 **Descrição:**
@@ -591,7 +591,7 @@ if (d.tipo === 'projecao' || d.tipo === 'projecao_paga') return false;  // BUG-0
 ### BUG-024 — `buscarChavesDedupReceitas` retorna `Set` — mesFatura não propagado para estornos duplicados
 **Severidade:** 🟠 Médio
 **Versão introduzida:** v3.8.0 (BUG-021)
-**Versão corrigida:** v3.9.0
+**Versão corrigida:** v3.9.0 (parcial) / v3.9.2 (completa)
 **Arquivos:** `src/js/services/database.js`, `src/js/pages/importar.js`
 
 **Descrição:**
@@ -606,6 +606,7 @@ Se um estorno/crédito da fatura já havia sido importado em ciclo anterior, o c
 **Correção aplicada:**
 1. `database.js`: `buscarChavesDedupReceitas` agora retorna `Map<chave_dedup, docId>` (mesmo padrão de `buscarChavesDedup`)
 2. `importar.js`: adicionado `atualizarReceita` ao import; post-loop distingue `tipoLinha === 'receita'` e chama `atualizarReceita` ou `atualizarDespesa` conforme o tipo do duplicado
+3. **Follow-up v3.9.2:** em `marcarDuplicatas`, o carregamento de chaves de receita também passou a cobrir `_tipoExtrato === 'cartao'` (antes cobria apenas `banco|receita`). Isso fecha o gap de dedup para estornos em fatura de cartão.
 
 ---
 

--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -72,6 +72,7 @@ import { categorizarTransacao }  from '../utils/categorizer.js';               /
 // RF-013: pipeline modules
 import { parsearCSVTexto, parsearLinhasCSVXLSX, parsearParcela, inferirContaDaDescricao } from '../utils/normalizadorTransacoes.js';
 import { marcarLinhasDuplicatas } from '../utils/deduplicador.js';
+import { deveCarregarChavesReceitas } from '../utils/importarDedup.js';
 import { parsearLinhasPDF, classificarBanco } from './pipelineBanco.js';
 import { filtrarCreditos, aplicarMesFatura, gerarProjecoes } from './pipelineCartao.js';
 
@@ -339,7 +340,7 @@ async function marcarDuplicatas() {
   // Cartão também pode conter estornos/créditos (tipoLinha='receita') no mesmo arquivo.
   // Sem carregar chaves de receitas aqui, duplicatas de estorno passam batido e
   // não recebem atualização de mesFatura em imports de ciclos futuros.
-  _chavesExistentesRec = (_tipoExtrato === 'banco' || _tipoExtrato === 'receita' || _tipoExtrato === 'cartao')
+  _chavesExistentesRec = deveCarregarChavesReceitas(_tipoExtrato)
     ? await buscarChavesDedupReceitas(_grupoId)
     : new Set();
   _projecaoDocMap      = await buscarMapaProjecoes(_grupoId);

--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -336,7 +336,10 @@ async function processarArquivo(file) {
 async function marcarDuplicatas() {
   _chavesExistentes    = await buscarChavesDedup(_grupoId);
   // NRF-006: carrega chaves de receitas quando em modo banco (mixed credits/debits)
-  _chavesExistentesRec = (_tipoExtrato === 'banco' || _tipoExtrato === 'receita')
+  // Cartão também pode conter estornos/créditos (tipoLinha='receita') no mesmo arquivo.
+  // Sem carregar chaves de receitas aqui, duplicatas de estorno passam batido e
+  // não recebem atualização de mesFatura em imports de ciclos futuros.
+  _chavesExistentesRec = (_tipoExtrato === 'banco' || _tipoExtrato === 'receita' || _tipoExtrato === 'cartao')
     ? await buscarChavesDedupReceitas(_grupoId)
     : new Set();
   _projecaoDocMap      = await buscarMapaProjecoes(_grupoId);

--- a/src/js/utils/importarDedup.js
+++ b/src/js/utils/importarDedup.js
@@ -1,0 +1,14 @@
+// ============================================================
+// UTIL: Regras de deduplicação do fluxo de importação
+// ============================================================
+
+/**
+ * Define quando a importação precisa carregar chaves de dedup da coleção de receitas.
+ * Cartão pode conter estornos/créditos (tipoLinha='receita') no mesmo arquivo.
+ * @param {string} tipoExtrato
+ * @returns {boolean}
+ */
+export function deveCarregarChavesReceitas(tipoExtrato) {
+  return tipoExtrato === 'banco' || tipoExtrato === 'receita' || tipoExtrato === 'cartao';
+}
+

--- a/tests/utils/importarDedup.test.js
+++ b/tests/utils/importarDedup.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { deveCarregarChavesReceitas } from '../../src/js/utils/importarDedup.js';
+
+describe('deveCarregarChavesReceitas', () => {
+  it('retorna true para banco', () => {
+    expect(deveCarregarChavesReceitas('banco')).toBe(true);
+  });
+
+  it('retorna true para receita', () => {
+    expect(deveCarregarChavesReceitas('receita')).toBe(true);
+  });
+
+  it('retorna true para cartao (estornos em fatura)', () => {
+    expect(deveCarregarChavesReceitas('cartao')).toBe(true);
+  });
+
+  it('retorna false para despesa', () => {
+    expect(deveCarregarChavesReceitas('despesa')).toBe(false);
+  });
+});
+


### PR DESCRIPTION
### Motivation
- Corrigir um caso em que estornos/créditos presentes em arquivos de fatura de cartão não eram marcados como duplicatas nem tinham `mesFatura` atualizado, deixando transações invisíveis em ciclos futuros.

### Description
- Em `src/js/pages/importar.js` a função `marcarDuplicatas` agora inclui `_tipoExtrato === 'cartao'` na condição que carrega `buscarChavesDedupReceitas`, garantindo que as chaves de deduplicação de `receitas` sejam carregadas também para imports de cartão.

### Testing
- Executado `npm test` e todos os testes automatizados da suíte passaram (`181 tests`, todas verdes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cac860db208322acc1e397ddad06cf)