### PR TITLE
fix(importar/base-dados): corrigir bugs do code review

### DIFF
--- a/src/base-dados.html
+++ b/src/base-dados.html
@@ -307,6 +307,7 @@
             </select>
           </div>
           <div class="modal-footer" style="display:flex;gap:.75rem;justify-content:flex-end;">
+            <button id="modal-tipo-cancelar" class="btn btn-secondary btn-sm">Cancelar</button>
             <button id="modal-tipo-confirmar" class="btn btn-primary btn-sm">Confirmar tipo</button>
           </div>
         </div>

--- a/src/js/pages/base-dados.js
+++ b/src/js/pages/base-dados.js
@@ -218,7 +218,7 @@ function preencherFiltrosResponsaveis() {
       .filter(Boolean)
   )].sort((a, b) => a.localeCompare(b));
   sel.innerHTML = '<option value="">Todos os responsáveis</option>' +
-    nomes.map(n => `<option value="${n}">${n}</option>`).join('');
+    nomes.map(n => `<option value="${escHTML(n)}">${escHTML(n)}</option>`).join('');
   if (atual) sel.value = atual;
 }
 
@@ -508,13 +508,7 @@ function configurarLimpeza() {
       const resultado = await purgeGrupoCompleto(_grupoId);
       modal?.classList.add('hidden');
       const total = resultado.despesas + resultado.receitas + resultado.parcelamentos;
-      alert(
-        `✅ Purge concluído!\n\n` +
-        `Despesas removidas: ${resultado.despesas}\n` +
-        `Receitas removidas: ${resultado.receitas}\n` +
-        `Parcelamentos removidos: ${resultado.parcelamentos}\n` +
-        `Total: ${total} registros`
-      );
+      mostrarToast(`✅ Purge concluído — ${total} registros removidos (${resultado.despesas} despesas, ${resultado.receitas} receitas, ${resultado.parcelamentos} parcelamentos)`);
       // Limpar cache local
       _todasTransacoes = [];
       _filtradas = [];

--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -90,14 +90,14 @@ let _contaMap = {};         // NRF-004: id → conta
 let _unsubCats = null;
 let _unsubContas = null;    // NRF-004
 let _linhas = [];
-let _chavesExistentes = new Set();
+let _chavesExistentes = new Map();
 let _projecaoDocMap = new Map();
 let _mapaCategoriasHist = {};
 let _projecoesDetalhadas = [];  // NRF-002: dados completos para fuzzy matching
 // NRF-006: tipo do extrato detectado/selecionado — 'cartao' | 'banco' | 'receita' | 'despesa'
 let _tipoExtrato = 'despesa';
 let _mesFatura = '';            // NRF-002.1: "YYYY-MM" selecionado pelo usuário
-let _chavesExistentesRec = new Set(); // NRF-006: dedup receitas (modo banco)
+let _chavesExistentesRec = new Map(); // NRF-006: dedup receitas (modo banco)
 // RF-020: estado específico de PDF
 let _origemPDF = false;         // true quando o arquivo carregado é PDF
 let _sinaisInvertidos = false;  // toggle: inverte a convenção de sinal do banco
@@ -344,7 +344,7 @@ async function marcarDuplicatas() {
   // não recebem atualização de mesFatura em imports de ciclos futuros.
   _chavesExistentesRec = deveCarregarChavesReceitas(_tipoExtrato)
     ? await buscarChavesDedupReceitas(_grupoId)
-    : new Set();
+    : new Map();
   _projecaoDocMap      = await buscarMapaProjecoes(_grupoId);
   _mapaCategoriasHist  = await buscarMapaCategorias(_grupoId);
   // NRF-002: busca projeções apenas para tipos que geram parcelas
@@ -381,6 +381,10 @@ function _mostrarModalConfirmacaoTipo(deteccao) {
       const tipo = document.getElementById('modal-sel-tipo-confirm').value;
       document.getElementById('modal-confirmacao-tipo').classList.add('hidden');
       resolve(tipo);
+    };
+    document.getElementById('modal-tipo-cancelar').onclick = () => {
+      document.getElementById('modal-confirmacao-tipo').classList.add('hidden');
+      resolve(deteccao.tipo);  // resolve com sugestão original ao cancelar
     };
   });
 }
@@ -940,7 +944,7 @@ async function executarImportacao() {
         }
       }
       sucesso++;
-    } catch { falha++; }
+    } catch (err) { console.error('[importar] erro na linha', idx, err); falha++; }
   }
   // BUG-021: propaga mesFatura nas duplicatas detectadas (parceladas de meses anteriores)
   // BUG-024: distingue receitas (estornos) de despesas ao atualizar mesFatura

--- a/src/js/utils/deduplicador.js
+++ b/src/js/utils/deduplicador.js
@@ -10,14 +10,14 @@ import { detectarAjustesParciais } from './ajusteDetector.js';  // NRF-002.2
 // Mantém Firestore fora: o chamador fornece os conjuntos pré-buscados.
 //
 // params:
-//   chavesDesp: Set<string>          — chaves de despesas existentes no Firestore
-//   chavesRec: Set<string>           — chaves de receitas existentes no Firestore
+//   chavesDesp: Map<string,string>    — chave_dedup → docId de despesas existentes no Firestore
+//   chavesRec: Map<string,string>    — chave_dedup → docId de receitas existentes no Firestore
 //   projecaoDocMap: Map<string,string> — chave_dedup → docId das projeções
 //   projecoesDetalhadas: Array       — projeções completas para fuzzy matching
 //   tipoExtrato: string              — 'cartao'|'banco'|'receita'|'despesa'
 export function marcarLinhasDuplicatas(linhas, {
-  chavesDesp = new Set(),
-  chavesRec = new Set(),
+  chavesDesp = new Map(),
+  chavesRec = new Map(),
   projecaoDocMap = new Map(),
   projecoesDetalhadas = [],
   tipoExtrato = 'despesa',


### PR DESCRIPTION
## Summary
- **Modal de tipo sem cancelamento**: Promise travava o fluxo se usuário não clicasse "Confirmar". Adicionado botão "Cancelar" que resolve com tipo sugerido original
- **Set→Map**: `_chavesExistentes`, `_chavesExistentesRec` e defaults do `deduplicador.js` inicializavam como `Set` mas eram usados como `Map` (`.set()`, `.get()`)
- **JSDoc incorreto**: `deduplicador.js` documentava `Set<string>` mas parâmetros reais são `Map<string,string>`
- **Catch silencioso**: `executarImportacao` engolia exceções sem log — adicionado `console.error`
- **XSS em responsáveis**: `preencherFiltrosResponsaveis` usava innerHTML sem escaping — aplicado `escHTML()`
- **alert→mostrarToast**: Purge usava `alert()` inconsistente com design system

## Arquivos modificados
- `src/base-dados.html` — botão cancelar no modal
- `src/js/pages/importar.js` — Set→Map, handler cancelar, console.error
- `src/js/utils/deduplicador.js` — JSDoc e defaults corrigidos
- `src/js/pages/base-dados.js` — escHTML + mostrarToast

## Test plan
- [ ] Importar CSV com confiança baixa → modal deve ter botão Cancelar funcional
- [ ] Clicar Cancelar → fluxo continua com tipo sugerido
- [ ] Importar com linha inválida → console.error aparece no DevTools
- [ ] Aba Gerenciar com nomes especiais → sem quebra de HTML
- [ ] Executar purge → toast em vez de alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)