### PR TITLE
feat(build): migrar imports Firebase de CDN para npm (#74)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@firebase/rules-unit-testing": "^3.0.0",
         "@vitest/coverage-v8": "^2.0.0",
-        "firebase": "^10.7.1",
+        "firebase": "^10.14.1",
         "firebase-tools": "^13.0.0",
         "vite": "^5.4.21",
         "vitest": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   ],
   "author": "Luigi",
   "license": "MIT",
+  "dependencies": {
+    "firebase": "^10.14.1"
+  },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^3.0.0",
     "@vitest/coverage-v8": "^2.0.0",
-    "firebase": "^10.7.1",
     "firebase-tools": "^13.0.0",
     "vite": "^5.4.21",
     "vitest": "^2.0.0"

--- a/src/index.html
+++ b/src/index.html
@@ -25,28 +25,6 @@
 <body>
   <p>Carregando…</p>
 
-  <script type="module">
-    import { auth } from './js/config/firebase.js';
-    import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js';
-    import { buscarPerfil } from './js/services/database.js';
-
-    // RF-017: redireciona baseado no estado de autenticação (não faz logout)
-    onAuthStateChanged(auth, async (user) => {
-      if (!user) {
-        window.location.replace('login.html');
-        return;
-      }
-      try {
-        const perfil = await buscarPerfil(user.uid);
-        if (perfil?.grupoId) {
-          window.location.replace('dashboard.html');
-        } else {
-          window.location.replace('grupo.html');
-        }
-      } catch (_) {
-        window.location.replace('login.html');
-      }
-    });
-  </script>
+  <script type="module" src="./js/pages/index.js"></script>
 </body>
 </html>

--- a/src/js/config/firebase.js
+++ b/src/js/config/firebase.js
@@ -7,12 +7,12 @@
 // ⚠️  NUNCA commite credenciais reais no GitHub!
 // ============================================================
 
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js';
+import { initializeApp } from 'firebase/app';
 import {
   initializeAuth,
   browserSessionPersistence,
-} from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js';
-import { getFirestore }  from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
+} from 'firebase/auth';
+import { getFirestore }  from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey:            'AIzaSyCm0DBw1sFiUG59_iL8Ofht7QJrcvssMc4',

--- a/src/js/pages/index.js
+++ b/src/js/pages/index.js
@@ -1,0 +1,25 @@
+// ============================================================
+// PORTÃO DE ENTRADA — RF-017
+// Redireciona para Dashboard se autenticado, ou Login se não.
+// ============================================================
+
+import { auth } from '../config/firebase.js';
+import { onAuthStateChanged } from 'firebase/auth';
+import { buscarPerfil } from '../services/database.js';
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.replace('login.html');
+    return;
+  }
+  try {
+    const perfil = await buscarPerfil(user.uid);
+    if (perfil?.grupoId) {
+      window.location.replace('dashboard.html');
+    } else {
+      window.location.replace('grupo.html');
+    }
+  } catch (_) {
+    window.location.replace('login.html');
+  }
+});

--- a/src/js/services/auth.js
+++ b/src/js/services/auth.js
@@ -9,7 +9,7 @@ import {
   signOut,
   onAuthStateChanged,
   sendPasswordResetEmail,
-} from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js';
+} from 'firebase/auth';
 import { criarPerfil, buscarPerfil } from './database.js';
 
 /**

--- a/src/js/services/database.js
+++ b/src/js/services/database.js
@@ -21,7 +21,7 @@ import {
   limit,
   startAfter,
   getCountFromServer,
-} from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
+} from 'firebase/firestore';
 
 // ── Usuários ─────────────────────────────────────────────────
 

--- a/src/js/services/grupos.js
+++ b/src/js/services/grupos.js
@@ -16,7 +16,7 @@ import {
   getDocs,
   arrayUnion,
   serverTimestamp,
-} from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
+} from 'firebase/firestore';
 import { criarGrupo } from '../models/Grupo.js';
 import { CATEGORIAS_PADRAO } from '../models/Categoria.js';
 


### PR DESCRIPTION
## Summary
- Migrados todos os 7 imports Firebase de CDN (gstatic.com) para pacotes npm
- Script inline de `index.html` extraído para `js/pages/index.js`
- Firebase movido de `devDependencies` para `dependencies`
- Vite agora faz tree-shaking do Firebase SDK (bundle ~102 kB gzip)

## Por que
Pré-requisito para Capacitor iOS (Fase 1). CDN imports não funcionam em apps nativos. Issue #74, milestone iOS.

## Test plan
- [ ] `npm run build` — deve gerar `dist/` sem erros, Firebase bundled
- [ ] `npm test` — todos os 194 testes Vitest devem passar
- [ ] `grep -r "gstatic.com" src/` — deve retornar zero resultados
- [ ] `npm run dev` — app funcional no dev server

## Checklist
- [x] Testes passando (`npm test` — 194/194)
- [x] Build sem erros (`npm run build`)
- [x] Zero imports CDN restantes
- [x] Sem secrets ou credenciais no diff

Fecha: #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)