### PR TITLE
refactor(utils): unificar lógica de importação — TD-006 (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ---
 
+## [3.20.0] - 2026-04-08
+
+### Refatorado
+
+- **Unificação da lógica de importação (#96):** criado módulo genérico `importacaoComum.js` com funções compartilhadas entre `importar.js` e `receitas.js` — leitura de CSV/XLSX, normalização de valores para receitas, resolução de contas/categorias por nome, parser de linhas de receitas e helpers de UI. Eliminadas ~200 linhas de código duplicado em `receitas.js` e ~70 linhas em `importar.js`.
+
+### Adicionado
+
+- Testes unitários para `importacaoComum.js` (34 testes) e `capacitor.js` (3 testes). Suite total: 231 testes.
+
+**Milestone "Melhoria de Manutenibilidade e Arquitetura": CONCLUÍDO** (issue #96 fechada).
+
+---
+
 ## [3.19.0] - 2026-04-07
 
 ### Adicionado — Fase 1: Capacitor + Safe Areas (Milestone iOS)

--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -75,6 +75,7 @@ import { categorizarTransacao }  from '../utils/categorizer.js';               /
 import { parsearCSVTexto, parsearLinhasCSVXLSX, parsearParcela, inferirContaDaDescricao } from '../utils/normalizadorTransacoes.js';
 import { marcarLinhasDuplicatas } from '../utils/deduplicador.js';
 import { deveCarregarChavesReceitas } from '../utils/importarDedup.js';
+import { detectarFormato, lerArquivoCSV, lerArquivoXLSX, mostrarArquivoUI, mostrarErroUI, preencherSelectsContasUI, resetarUploadUI } from '../utils/importacaoComum.js';
 import { parsearLinhasPDF, classificarBanco } from './pipelineBanco.js';
 import { filtrarCreditos, aplicarMesFatura, gerarProjecoes } from './pipelineCartao.js';
 
@@ -245,24 +246,21 @@ function configurarEventos() {
 // ── Processar arquivo ───────────────────────────────────────────
 async function processarArquivo(file) {
   document.getElementById('erro-leitura').classList.add('hidden');
-  const isCSV  = /\.csv$/i.test(file.name);
-  const isXLSX = /\.(xlsx|xls)$/i.test(file.name);
-  const isPDF  = /\.pdf$/i.test(file.name);
-  if (!isCSV && !isXLSX && !isPDF) {
-    mostrarErroLeitura('Formato não suportado. Use extrato CSV, Excel (.xlsx) ou PDF bancário.');
+  const formato = detectarFormato(file.name);
+  if (!formato) {
+    mostrarErroUI('Formato não suportado. Use extrato CSV, Excel (.xlsx) ou PDF bancário.', 'erro-leitura');
     return;
   }
   // RF-020: pipeline PDF
-  if (isPDF) {
+  if (formato === 'pdf') {
     _origemPDF = true;
     _sinaisInvertidos = false;
     try {
       const raw = await extrairTransacoesPDF(file);
-      if (!raw.length) { mostrarErroLeitura('Nenhuma transação encontrada no PDF. Verifique se é um extrato bancário com texto selecionável.'); return; }
+      if (!raw.length) { mostrarErroUI('Nenhuma transação encontrada no PDF. Verifique se é um extrato bancário com texto selecionável.', 'erro-leitura'); return; }
       const contaGlobal = document.getElementById('sel-conta-global')?.value ?? '';
       _linhas = parsearLinhasPDF(raw, { contas: _contas, categorias: _categorias, mapaHist: _mapaCategoriasHist, origemBanco: 'desconhecido', contaGlobal });
-      if (!_linhas.length) { mostrarErroLeitura('Nenhuma linha válida extraída do PDF.'); return; }
-      // RF-021: detecta banco pelo nome do arquivo + descrições extraídas
+      if (!_linhas.length) { mostrarErroUI('Nenhuma linha válida extraída do PDF.', 'erro-leitura'); return; }
       const detPDF = detectarOrigemArquivo({ fileName: file.name, textLines: raw.map(r => r.desc) });
       _origemBanco = detPDF.origem;
       _origemLabel = detPDF.origemLabel;
@@ -273,10 +271,10 @@ async function processarArquivo(file) {
       _atualizarUIInverterSinais(true);
       _atualizarBancoBadge();
       _autoSelecionarConta(_origemBanco);
-      mostrarArquivoSelecionado(file.name);
-      await _reprocessarLinhas(); // TD-002
+      _mostrarArquivoSelecionado(file.name);
+      await _reprocessarLinhas();
     } catch (err) {
-      mostrarErroLeitura('Erro ao ler o PDF: ' + err.message);
+      mostrarErroUI('Erro ao ler o PDF: ' + err.message, 'erro-leitura');
     }
     return;
   }
@@ -286,14 +284,13 @@ async function processarArquivo(file) {
   _origemLabel = '';
   _origemEmoji = '';
   _atualizarUIInverterSinais(false);
-  if (isCSV) {
+  if (formato === 'csv') {
     const reader = new FileReader();
     reader.onload = async (e) => {
       try {
         const rows = parsearCSVTexto(e.target.result);
         _linhas = parsearLinhasCSVXLSX(rows, { contas: _contas, categorias: _categorias, mapaHist: _mapaCategoriasHist, origemBanco: 'desconhecido' });
-        if (!_linhas.length) { mostrarErroLeitura('Nenhuma transação encontrada. Verifique se o arquivo està no formato correto.'); return; }
-        // RF-021: detecta tipo + banco
+        if (!_linhas.length) { mostrarErroUI('Nenhuma transação encontrada. Verifique se o arquivo està no formato correto.', 'erro-leitura'); return; }
         const det1 = detectarOrigemArquivo({ fileName: file.name, rows });
         _origemBanco = det1.origem; _origemLabel = det1.origemLabel; _origemEmoji = det1.origemEmoji;
         _recategorizarComOrigem();
@@ -302,37 +299,29 @@ async function processarArquivo(file) {
         _atualizarUITipo();
         _atualizarBancoBadge();
         _autoSelecionarConta(_origemBanco);
-        mostrarArquivoSelecionado(file.name);
+        _mostrarArquivoSelecionado(file.name);
         await _reprocessarLinhas(); // TD-002
-      } catch (err) { mostrarErroLeitura('Erro ao ler o CSV: ' + err.message); }
+      } catch (err) { mostrarErroUI('Erro ao ler o CSV: ' + err.message, 'erro-leitura'); }
     };
     reader.readAsText(file, 'UTF-8');
     return;
   }
-  const reader = new FileReader();
-  reader.onload = async (e) => {
-    try {
-      const data = new Uint8Array(e.target.result);
-      const wb   = XLSX.read(data, { type: 'array', cellDates: true });
-      const name = wb.SheetNames.find(n => /extrato|transa/i.test(n)) ?? wb.SheetNames[0];
-      const ws   = wb.Sheets[name];
-      const rows = XLSX.utils.sheet_to_json(ws, { header: 1, raw: false, dateNF: 'DD/MM/YYYY' });
-      _linhas = parsearLinhasCSVXLSX(rows, { contas: _contas, categorias: _categorias, mapaHist: _mapaCategoriasHist, origemBanco: 'desconhecido' });
-      if (!_linhas.length) { mostrarErroLeitura('Nenhuma transação encontrada no arquivo.'); return; }
-      // RF-021: detecta tipo + banco
-      const det2 = detectarOrigemArquivo({ fileName: file.name, rows });
-      _origemBanco = det2.origem; _origemLabel = det2.origemLabel; _origemEmoji = det2.origemEmoji;
-      _recategorizarComOrigem();
-      const tipo2 = det2.confianca === 'baixa' ? await _mostrarModalConfirmacaoTipo(det2) : det2.tipo;
-      _aplicarTipo(tipo2);
-      _atualizarUITipo();
-      _atualizarBancoBadge();
-      _autoSelecionarConta(_origemBanco);
-      mostrarArquivoSelecionado(file.name);
-      await _reprocessarLinhas(); // TD-002
-    } catch (err) { mostrarErroLeitura('Erro ao ler o Excel: ' + err.message); }
-  };
-  reader.readAsArrayBuffer(file);
+  // XLSX
+  try {
+    const rows = await lerArquivoXLSX(file, /extrato|transa/i);
+    _linhas = parsearLinhasCSVXLSX(rows, { contas: _contas, categorias: _categorias, mapaHist: _mapaCategoriasHist, origemBanco: 'desconhecido' });
+    if (!_linhas.length) { mostrarErroUI('Nenhuma transação encontrada no arquivo.', 'erro-leitura'); return; }
+    const det2 = detectarOrigemArquivo({ fileName: file.name, rows });
+    _origemBanco = det2.origem; _origemLabel = det2.origemLabel; _origemEmoji = det2.origemEmoji;
+    _recategorizarComOrigem();
+    const tipo2 = det2.confianca === 'baixa' ? await _mostrarModalConfirmacaoTipo(det2) : det2.tipo;
+    _aplicarTipo(tipo2);
+    _atualizarUITipo();
+    _atualizarBancoBadge();
+    _autoSelecionarConta(_origemBanco);
+    _mostrarArquivoSelecionado(file.name);
+    await _reprocessarLinhas(); // TD-002
+  } catch (err) { mostrarErroUI('Erro ao ler o Excel: ' + err.message, 'erro-leitura'); }
 }
 
 
@@ -1006,15 +995,9 @@ function mostrarResultado(sucesso, falha, projGeradas, reconciliacoes, reconcili
   document.getElementById('sec-resultado').classList.remove('hidden');
 }
 
-// ── Helpers de UI ;
-function mostrarArquivoSelecionado(nome) {
-  document.getElementById('drop-area').classList.add('hidden');
-  document.getElementById('arquivo-info').classList.remove('hidden');
-  document.getElementById('arquivo-nome').textContent = nome;
-}
-function mostrarErroLeitura(msg) {
-  const el = document.getElementById('erro-leitura');
-  el.textContent = msg; el.classList.remove('hidden');
+// ── Helpers de UI — mostrarErroLeitura delegado a importacaoComum.mostrarErroUI ──
+function _mostrarArquivoSelecionado(nome) {
+  mostrarArquivoUI(nome, { dropAreaId: 'drop-area', arquivoInfoId: 'arquivo-info', arquivoNomeId: 'arquivo-nome' });
 }
 function preencherSelCatLote() {
   const sel = document.getElementById('sel-cat-lote');
@@ -1044,29 +1027,15 @@ function preencherSelRespLote() {
     `<option value="${RESP_CONJUNTO}">👥 Conjunto</option>`;
 }
 
-// NRF-004: preenche todos os selects de conta (global, lote e por linha)
+// NRF-004: preenche todos os selects de conta — delegado a importacaoComum.js
 function preencherSelectsContas() {
-  const optStr = '<option value="">— sem conta —</option>' +
-    _contas.map(c => '<option value="' + c.id + '">' + c.emoji + ' ' + c.nome + '</option>').join('');
-  const optStrNeutro = '<option value="">— manter individual —</option>' +
-    _contas.map(c => '<option value="' + c.id + '">' + c.emoji + ' ' + c.nome + '</option>').join('');
-  const selGlobal = document.getElementById('sel-conta-global');
-  if (selGlobal) { const v = selGlobal.value; selGlobal.innerHTML = optStr; selGlobal.value = v; }
-  const selLote = document.getElementById('sel-conta-lote');
-  if (selLote)   { const v = selLote.value;   selLote.innerHTML = optStrNeutro; selLote.value = v; }
-  // Por linha (no preview)
-  document.querySelectorAll('.sel-conta-linha').forEach((sel) => {
-    const idx = +sel.dataset.idx, atual = sel.value;
-    sel.innerHTML = optStr;
-    sel.value = atual || _linhas[idx]?.contaId || '';
+  preencherSelectsContasUI(_contas, {
+    globalId: 'sel-conta-global', loteId: 'sel-conta-lote',
+    linhaClass: 'sel-conta-linha', linhasArray: _linhas,
   });
 }
 function resetarUpload() {
-  document.getElementById('file-input').value = '';
-  document.getElementById('drop-area').classList.remove('hidden');
-  document.getElementById('arquivo-info').classList.add('hidden');
-  document.getElementById('erro-leitura').classList.add('hidden');
-  document.getElementById('sec-preview').classList.add('hidden');
+  resetarUploadUI({ fileInputId: 'file-input', dropAreaId: 'drop-area', arquivoInfoId: 'arquivo-info', erroId: 'erro-leitura', previewSecId: 'sec-preview' });
   document.getElementById('tipo-extrato-wrap')?.classList.add('hidden'); // NRF-006
   _linhas = [];
   _tipoExtrato = 'despesa';         // NRF-006

--- a/src/js/pages/receitas.js
+++ b/src/js/pages/receitas.js
@@ -18,6 +18,11 @@ import { modelReceita, CATEGORIAS_RECEITA_PADRAO } from '../models/Receita.js';
 import { formatarMoeda, formatarData, nomeMes, escHTML } from '../utils/formatters.js';
 import { dataHoje } from '../utils/helpers.js';
 import { skeletonCards, emptyStateHTML, errorStateHTML } from '../utils/skeletons.js';
+import {
+  detectarFormato, lerArquivoCSV, lerArquivoXLSX,
+  parsearLinhasReceita, mostrarArquivoUI, mostrarErroUI,
+  preencherSelectsContasUI, resetarUploadUI,
+} from '../utils/importacaoComum.js';
 
 // ── Estado da página ──────────────────────────────────────────
 let _usuario    = null;
@@ -407,179 +412,32 @@ function _gerarTemplateRec() {
   XLSX.writeFile(wb, 'template-receitas.xlsx');
 }
 
-// ── Parser de arquivo (CSV ou XLSX) ──────────────────────────
+// ── Parser de arquivo (CSV ou XLSX) — delegado a importacaoComum.js ──
 async function _processarArquivoRec(file) {
   document.getElementById('erro-leitura-rec').classList.add('hidden');
-  const isCSV  = /\.csv$/i.test(file.name);
-  const isXLSX = /\.(xlsx|xls)$/i.test(file.name);
-  if (!isCSV && !isXLSX) {
-    _mostrarErroRec('Formato não suportado. Use o template Excel (.xlsx) ou CSV.');
+  const formato = detectarFormato(file.name);
+  if (formato !== 'csv' && formato !== 'xlsx') {
+    mostrarErroUI('Formato não suportado. Use o template Excel (.xlsx) ou CSV.', 'erro-leitura-rec');
     return;
   }
-  // Carrega chaves de dedup da coleção receitas (corrigido: busca em receitas, não despesas)
   _chavesRec = await buscarChavesDedupReceitas(_grupoId).catch(() => new Set());
-
-  const _parse = (rows) => {
-    _linhasRec = _parsearLinhasRec(rows);
-    if (!_linhasRec.length) { _mostrarErroRec('Nenhuma receita encontrada no arquivo.'); return; }
-    _mostrarArquivoRec(file.name);
+  try {
+    const rows = formato === 'csv'
+      ? await lerArquivoCSV(file)
+      : await lerArquivoXLSX(file, /receit/i);
+    const contaGlobalId = document.getElementById('sel-conta-global-rec')?.value ?? '';
+    _linhasRec = parsearLinhasReceita(rows, { categorias: _categorias, contas: _contas, chavesRec: _chavesRec, contaGlobalId });
+    if (!_linhasRec.length) { mostrarErroUI('Nenhuma receita encontrada no arquivo.', 'erro-leitura-rec'); return; }
+    mostrarArquivoUI(file.name, { dropAreaId: 'drop-area-rec', arquivoInfoId: 'arquivo-info-rec', arquivoNomeId: 'arquivo-nome-rec' });
     _renderizarPreviewRec();
-  };
-
-  if (isCSV) {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      try {
-        const texto = e.target.result.replace(/^\uFEFF/, '');
-        const rows  = texto.split(/\r?\n/).filter(l => l.trim()).map(l => l.split(';').map(c => c.trim()));
-        _parse(rows);
-      } catch (err) { _mostrarErroRec('Erro ao ler o CSV: ' + err.message); }
-    };
-    reader.readAsText(file, 'UTF-8');
-  } else {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      try {
-        const wb   = XLSX.read(new Uint8Array(e.target.result), { type: 'array', cellDates: true });
-        const name = wb.SheetNames.find(n => /receit/i.test(n)) ?? wb.SheetNames[0];
-        const rows = XLSX.utils.sheet_to_json(wb.Sheets[name], { header: 1, raw: false, dateNF: 'DD/MM/YYYY' });
-        _parse(rows);
-      } catch (err) { _mostrarErroRec('Erro ao ler o Excel: ' + err.message); }
-    };
-    reader.readAsArrayBuffer(file);
+  } catch (err) {
+    mostrarErroUI('Erro ao ler o arquivo: ' + err.message, 'erro-leitura-rec');
   }
 }
 
-// ── Parse das linhas do extrato ───────────────────────────────
-function _parsearLinhasRec(rows) {
-  if (!rows.length) return [];
-  // Detecta linha de cabeçalho
-  let headerIdx = -1;
-  for (let i = 0; i < Math.min(rows.length, 10); i++) {
-    const r = rows[i].map(c => String(c ?? '').toLowerCase().trim());
-    if (r.some(c => c === 'data') && r.some(c => c.includes('descri') || c.includes('estabele'))) {
-      headerIdx = i; break;
-    }
-  }
-  let idxData = 0, idxDesc = 1, idxValor = 2, idxCat = 3, idxConta = 4;
-  if (headerIdx >= 0) {
-    const h = rows[headerIdx].map(c => String(c ?? '').toLowerCase().trim());
-    idxData  = h.findIndex(c => c === 'data');
-    idxDesc  = h.findIndex(c => c.includes('descri') || c.includes('estabele'));
-    idxValor = h.findIndex(c => c.includes('valor'));
-    idxCat   = h.findIndex(c => c.includes('categ'));
-    idxConta = h.findIndex(c => c.includes('conta') || c.includes('banco'));
-    if (idxData < 0)  idxData  = 0;
-    if (idxDesc < 0)  idxDesc  = 1;
-    if (idxValor < 0) idxValor = 2;
-  }
-  const dataRows = headerIdx >= 0 ? rows.slice(headerIdx + 1) : rows.slice(1);
-  const resultado = [];
-  for (const row of dataRows) {
-    if (!row?.some(c => c)) continue;
-    const dataRaw  = String(row[idxData]  ?? '').trim();
-    const desc     = String(row[idxDesc]  ?? '').trim();
-    const valorRaw = String(row[idxValor] ?? '').trim();
-    const catNome  = idxCat   >= 0 ? String(row[idxCat]   ?? '').trim() : '';
-    const contaNome = idxConta >= 0 ? String(row[idxConta] ?? '').trim() : '';
-    if (!dataRaw && !desc && !valorRaw) continue;
-    const valor = _normalizarValorRec(valorRaw);
-    const data  = _normalizarDataRec(dataRaw);
-    const erros = [];
-    if (!data)                         erros.push('Data inválida');
-    if (!desc)                         erros.push('Descrição vazia');
-    if (isNaN(valor) || valor <= 0)    erros.push('Valor inválido');
-    // Resolve categoria por nome (match case-insensitive)
-    const catObj  = catNome ? _categorias.find(c => c.nome.toLowerCase().includes(catNome.toLowerCase()) || catNome.toLowerCase().includes(c.nome.toLowerCase())) : null;
-    const catId   = catObj?.id ?? '';
-    // Resolve conta por nome (normalização de acentos para cobrir "Itau" → "Banco Itaú")
-    const _norm      = s => s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-    const contaNomeN = _norm(contaNome);
-    const contaObj   = contaNome ? _contas.find(c => {
-      const n = _norm(c.nome);
-      return n.includes(contaNomeN) || contaNomeN.includes(n);
-    }) : null;
-    // Prioridade: coluna Conta → inferência pelo valor da coluna → inferência pela descrição → seletor global
-    const contaId = contaObj?.id
-      || _inferirContaDaDescricao(contaNome, _contas)
-      || _inferirContaDaDescricao(desc, _contas)
-      || (document.getElementById('sel-conta-global-rec')?.value ?? '');
-    const chave    = erros.length ? null : _chaveDedup(data, desc, valor);
-    const duplicado = chave ? _chavesRec.has(chave) : false;
-    resultado.push({ _idx: resultado.length, data, descricao: desc, valor, categoriaId: catId, contaId, chave_dedup: chave, duplicado, erro: erros.length ? erros.join(', ') : null });
-  }
-  return resultado;
-}
-
-// ── NRF-004: Infere conta/banco a partir de palavras-chave na descrição ─────
-function _inferirContaDaDescricao(descricao, contas) {
-  if (!descricao || !contas.length) return '';
-  const d = descricao.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-
-  // 1. Match direto contra nomes das contas do grupo
-  for (const c of contas) {
-    const palavras = c.nome.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').split(/\s+/);
-    if (palavras.some(p => p.length > 3 && d.includes(p))) return c.id;
-  }
-
-  // 2. Mapa de palavras-chave → trecho do nome da conta
-  const BANCO_KEYWORDS = [
-    { keys: ['itau', 'itaú'],                              conta: 'itaú'       },
-    { keys: ['bradesco'],                                  conta: 'bradesco'   },
-    { keys: ['santander'],                                 conta: 'santander'  },
-    { keys: ['btg'],                                       conta: 'btg'        },
-    { keys: ['xp invest', 'xpinvest', 'xp corret', 'xp pagamento'], conta: 'xp' },
-    { keys: ['nubank', 'nu pagamento', 'nu financ'],       conta: 'nubank'     },
-    { keys: ['banco inter', 'inter pagamento'],            conta: 'inter'      },
-    { keys: ['c6 bank', 'c6bank', 'c6 pagamento'],         conta: 'c6'         },
-    { keys: ['caixa eco', 'cef ', 'cx eco'],               conta: 'caixa'      },
-    { keys: ['banco do brasil', 'bb seg', 'bb pag'],       conta: 'brasil'     },
-    { keys: ['sicoob', 'sicredi'],                         conta: 'sicoob'     },
-    { keys: ['original'],                                  conta: 'original'   },
-    { keys: ['next bank', 'next pag'],                     conta: 'next'       },
-    { keys: ['neon'],                                      conta: 'neon'       },
-    { keys: ['picpay'],                                    conta: 'picpay'     },
-    { keys: ['mercado pago', 'mercadopago'],               conta: 'mercado'    },
-    { keys: ['facilcred'],                                 conta: 'facilcred'  },
-  ];
-
-  for (const regra of BANCO_KEYWORDS) {
-    if (regra.keys.some(k => d.includes(k))) {
-      const match = contas.find(c =>
-        c.nome.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').includes(regra.conta)
-      );
-      if (match) return match.id;
-    }
-  }
-
-  return '';
-}
-
-function _normalizarValorRec(val) {
-  if (!val && val !== 0) return NaN;
-  if (typeof val === 'number') return Math.abs(val); // aceita negativos (extrato bancário)
-  const s = String(val).trim().replace(/R\$\s*/i, '').replace(/\./g, '').replace(',', '.');
-  return Math.abs(parseFloat(s));
-}
-
-function _normalizarDataRec(val) {
-  if (!val) return null;
-  if (val instanceof Date && !isNaN(val)) return val;
-  const s  = String(val).trim();
-  const m1 = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-  if (m1) return new Date(`${m1[3]}-${m1[2].padStart(2,'0')}-${m1[1].padStart(2,'0')}T12:00:00`);
-  const m2 = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (m2) return new Date(s + 'T12:00:00');
-  const d = new Date(s);
-  return isNaN(d) ? null : d;
-}
-
-function _chaveDedup(data, desc, valor) {
-  if (!data || isNaN(valor)) return null;
-  const iso  = (data instanceof Date ? data : new Date(data)).toISOString().slice(0, 10);
-  const norm = String(desc).toLowerCase().trim().replace(/\s+/g, ' ').substring(0, 60);
-  return `rec||${iso}||${norm}||${Number(valor).toFixed(2)}`;
-}
+// ── Parse de linhas e funções de normalização delegadas a importacaoComum.js ──
+// _parsearLinhasRec, _inferirContaDaDescricao, _normalizarValorRec,
+// _normalizarDataRec e _chaveDedup foram unificados em importacaoComum.js (TD-006)
 
 // ── Renderização da tabela de preview ────────────────────────
 function _renderizarPreviewRec() {
@@ -712,17 +570,7 @@ async function _executarImportacaoRec() {
   _mostrarResultadoRec(sucesso, falha);
 }
 
-// ── Helpers de UI ─────────────────────────────────────────────
-function _mostrarArquivoRec(nome) {
-  document.getElementById('drop-area-rec')?.classList.add('hidden');
-  document.getElementById('arquivo-info-rec')?.classList.remove('hidden');
-  document.getElementById('arquivo-nome-rec').textContent = nome;
-}
-
-function _mostrarErroRec(msg) {
-  const el = document.getElementById('erro-leitura-rec');
-  if (el) { el.textContent = msg; el.classList.remove('hidden'); }
-}
+// ── Helpers de UI — mostrarArquivo e mostrarErro delegados a importacaoComum.js ──
 
 function _mostrarResultadoRec(sucesso, falha) {
   document.getElementById('sec-preview-rec')?.classList.add('hidden');
@@ -742,11 +590,7 @@ function _mostrarResultadoRec(sucesso, falha) {
 }
 
 function _resetarUploadRec() {
-  document.getElementById('file-input-rec').value = '';
-  document.getElementById('drop-area-rec')?.classList.remove('hidden');
-  document.getElementById('arquivo-info-rec')?.classList.add('hidden');
-  document.getElementById('erro-leitura-rec')?.classList.add('hidden');
-  document.getElementById('sec-preview-rec')?.classList.add('hidden');
+  resetarUploadUI({ fileInputId: 'file-input-rec', dropAreaId: 'drop-area-rec', arquivoInfoId: 'arquivo-info-rec', erroId: 'erro-leitura-rec', previewSecId: 'sec-preview-rec' });
   _linhasRec = [];
 }
 
@@ -766,17 +610,8 @@ function _preencherLoteCatRec() {
 }
 
 function _preencherSelectsContasRec() {
-  const optStr = '<option value="">— sem conta —</option>' +
-    _contas.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
-  const optLote = '<option value="">— manter individual —</option>' +
-    _contas.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
-  const selGlobal = document.getElementById('sel-conta-global-rec');
-  if (selGlobal) { const v = selGlobal.value; selGlobal.innerHTML = optStr; selGlobal.value = v; }
-  const selLote = document.getElementById('sel-conta-lote-rec');
-  if (selLote) { const v = selLote.value; selLote.innerHTML = optLote; selLote.value = v; }
-  document.querySelectorAll('.sel-conta-linha-rec').forEach((sel) => {
-    const idx = +sel.dataset.idx, v = sel.value;
-    sel.innerHTML = optStr;
-    sel.value = v || _linhasRec[idx]?.contaId || '';
+  preencherSelectsContasUI(_contas, {
+    globalId: 'sel-conta-global-rec', loteId: 'sel-conta-lote-rec',
+    linhaClass: 'sel-conta-linha-rec', linhasArray: _linhasRec,
   });
 }

--- a/src/js/utils/importacaoComum.js
+++ b/src/js/utils/importacaoComum.js
@@ -1,0 +1,198 @@
+// ============================================================
+// UTIL: Módulo Genérico de Importação — TD-006 (#96)
+// Funções compartilhadas entre importar.js e receitas.js.
+// Elimina duplicação de leitura de arquivo, normalização e UI.
+// ============================================================
+
+import { normalizarValorXP, normalizarData, inferirContaDaDescricao } from './normalizadorTransacoes.js';
+
+// Re-exporta para que ambas as páginas importem daqui
+export { inferirContaDaDescricao };
+
+// ── Leitura de arquivo CSV → rows[][] ────────────────────────────
+export function lerArquivoCSV(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const texto = e.target.result.replace(/^\uFEFF/, '');
+        const rows = texto
+          .split(/\r?\n/)
+          .filter(l => l.trim())
+          .map(l => l.split(';').map(c => c.trim()));
+        resolve(rows);
+      } catch (err) { reject(err); }
+    };
+    reader.onerror = () => reject(new Error('Erro ao ler arquivo CSV'));
+    reader.readAsText(file, 'UTF-8');
+  });
+}
+
+// ── Leitura de arquivo XLSX → rows[][] ──────────────────────────
+// sheetNamePattern: RegExp opcional para selecionar aba por nome
+export function lerArquivoXLSX(file, sheetNamePattern = null) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const wb = XLSX.read(new Uint8Array(e.target.result), { type: 'array', cellDates: true });
+        const name = sheetNamePattern
+          ? (wb.SheetNames.find(n => sheetNamePattern.test(n)) ?? wb.SheetNames[0])
+          : wb.SheetNames[0];
+        const rows = XLSX.utils.sheet_to_json(wb.Sheets[name], { header: 1, raw: false, dateNF: 'DD/MM/YYYY' });
+        resolve(rows);
+      } catch (err) { reject(err); }
+    };
+    reader.onerror = () => reject(new Error('Erro ao ler arquivo Excel'));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+// ── Detectar formato do arquivo ─────────────────────────────────
+export function detectarFormato(fileName) {
+  if (/\.csv$/i.test(fileName)) return 'csv';
+  if (/\.(xlsx|xls)$/i.test(fileName)) return 'xlsx';
+  if (/\.pdf$/i.test(fileName)) return 'pdf';
+  return null;
+}
+
+// ── Chave de deduplicação para receitas ─────────────────────────
+export function gerarChaveDedupReceita(data, desc, valor) {
+  if (!data || isNaN(valor)) return null;
+  const iso = (data instanceof Date ? data : new Date(data)).toISOString().slice(0, 10);
+  const norm = String(desc).toLowerCase().trim().replace(/\s+/g, ' ').substring(0, 60);
+  return `rec||${iso}||${norm}||${Number(valor).toFixed(2)}`;
+}
+
+// ── Normalizar valor para receitas (sempre positivo) ────────────
+export function normalizarValorReceita(val) {
+  if (!val && val !== 0) return NaN;
+  if (typeof val === 'number') return Math.abs(val);
+  const v = normalizarValorXP(val);
+  return isNaN(v) ? NaN : Math.abs(v);
+}
+
+// ── Resolver conta por nome (match fuzzy) ───────────────────────
+// Tenta match direto pelo nome, depois delega para inferirContaDaDescricao.
+export function resolverContaPorNome(contaNome, contas) {
+  if (!contaNome || !contas.length) return '';
+  const _norm = s => s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const contaNomeN = _norm(contaNome);
+  const contaObj = contas.find(c => {
+    const n = _norm(c.nome);
+    return n.includes(contaNomeN) || contaNomeN.includes(n);
+  });
+  return contaObj?.id || inferirContaDaDescricao(contaNome, contas);
+}
+
+// ── Resolver categoria por nome (match case-insensitive) ────────
+export function resolverCategoriaPorNome(catNome, categorias) {
+  if (!catNome || !categorias.length) return '';
+  const catObj = categorias.find(c =>
+    c.nome.toLowerCase().includes(catNome.toLowerCase()) ||
+    catNome.toLowerCase().includes(c.nome.toLowerCase())
+  );
+  return catObj?.id ?? '';
+}
+
+// ── Parser genérico de linhas de receitas ────────────────────────
+// Extraído de receitas.js `_parsearLinhasRec` para reutilização.
+export function parsearLinhasReceita(rows, { categorias = [], contas = [], chavesRec = new Set(), contaGlobalId = '' } = {}) {
+  if (!rows.length) return [];
+  // Detecta linha de cabeçalho
+  let headerIdx = -1;
+  for (let i = 0; i < Math.min(rows.length, 10); i++) {
+    const r = rows[i].map(c => String(c ?? '').toLowerCase().trim());
+    if (r.some(c => c === 'data') && r.some(c => c.includes('descri') || c.includes('estabele'))) {
+      headerIdx = i; break;
+    }
+  }
+  let idxData = 0, idxDesc = 1, idxValor = 2, idxCat = 3, idxConta = 4;
+  if (headerIdx >= 0) {
+    const h = rows[headerIdx].map(c => String(c ?? '').toLowerCase().trim());
+    idxData  = h.findIndex(c => c === 'data');
+    idxDesc  = h.findIndex(c => c.includes('descri') || c.includes('estabele'));
+    idxValor = h.findIndex(c => c.includes('valor'));
+    idxCat   = h.findIndex(c => c.includes('categ'));
+    idxConta = h.findIndex(c => c.includes('conta') || c.includes('banco'));
+    if (idxData < 0)  idxData  = 0;
+    if (idxDesc < 0)  idxDesc  = 1;
+    if (idxValor < 0) idxValor = 2;
+  }
+  const dataRows = headerIdx >= 0 ? rows.slice(headerIdx + 1) : rows.slice(1);
+  const resultado = [];
+  for (const row of dataRows) {
+    if (!row?.some(c => c)) continue;
+    const dataRaw   = String(row[idxData]  ?? '').trim();
+    const desc      = String(row[idxDesc]  ?? '').trim();
+    const valorRaw  = String(row[idxValor] ?? '').trim();
+    const catNome   = idxCat   >= 0 ? String(row[idxCat]   ?? '').trim() : '';
+    const contaNome = idxConta >= 0 ? String(row[idxConta] ?? '').trim() : '';
+    if (!dataRaw && !desc && !valorRaw) continue;
+    const valor = normalizarValorReceita(valorRaw);
+    const data  = normalizarData(dataRaw);
+    const erros = [];
+    if (!data)                      erros.push('Data inválida');
+    if (!desc)                      erros.push('Descrição vazia');
+    if (isNaN(valor) || valor <= 0) erros.push('Valor inválido');
+    const catId   = resolverCategoriaPorNome(catNome, categorias);
+    const contaId = resolverContaPorNome(contaNome, contas)
+      || inferirContaDaDescricao(desc, contas)
+      || contaGlobalId;
+    const chave    = erros.length ? null : gerarChaveDedupReceita(data, desc, valor);
+    const duplicado = chave ? chavesRec.has(chave) : false;
+    resultado.push({
+      _idx: resultado.length, data, descricao: desc, valor,
+      categoriaId: catId, contaId, chave_dedup: chave,
+      duplicado, erro: erros.length ? erros.join(', ') : null,
+    });
+  }
+  return resultado;
+}
+
+// ── UI: Mostrar arquivo selecionado ─────────────────────────────
+export function mostrarArquivoUI(nomeArquivo, { dropAreaId, arquivoInfoId, arquivoNomeId }) {
+  document.getElementById(dropAreaId)?.classList.add('hidden');
+  document.getElementById(arquivoInfoId)?.classList.remove('hidden');
+  const el = document.getElementById(arquivoNomeId);
+  if (el) el.textContent = nomeArquivo;
+}
+
+// ── UI: Mostrar erro de leitura ─────────────────────────────────
+export function mostrarErroUI(msg, erroElementId) {
+  const el = document.getElementById(erroElementId);
+  if (el) { el.textContent = msg; el.classList.remove('hidden'); }
+}
+
+// ── UI: Preencher selects de contas ─────────────────────────────
+export function preencherSelectsContasUI(contas, { globalId, loteId, linhaClass, linhasArray }) {
+  const optStr = '<option value="">— sem conta —</option>' +
+    contas.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
+  const optLote = '<option value="">— manter individual —</option>' +
+    contas.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
+  if (globalId) {
+    const selGlobal = document.getElementById(globalId);
+    if (selGlobal) { const v = selGlobal.value; selGlobal.innerHTML = optStr; selGlobal.value = v; }
+  }
+  if (loteId) {
+    const selLote = document.getElementById(loteId);
+    if (selLote) { const v = selLote.value; selLote.innerHTML = optLote; selLote.value = v; }
+  }
+  if (linhaClass && linhasArray) {
+    document.querySelectorAll(`.${linhaClass}`).forEach((sel) => {
+      const idx = +sel.dataset.idx, v = sel.value;
+      sel.innerHTML = optStr;
+      sel.value = v || linhasArray[idx]?.contaId || '';
+    });
+  }
+}
+
+// ── UI: Resetar área de upload ──────────────────────────────────
+export function resetarUploadUI({ fileInputId, dropAreaId, arquivoInfoId, erroId, previewSecId }) {
+  const fileInput = document.getElementById(fileInputId);
+  if (fileInput) fileInput.value = '';
+  document.getElementById(dropAreaId)?.classList.remove('hidden');
+  document.getElementById(arquivoInfoId)?.classList.add('hidden');
+  document.getElementById(erroId)?.classList.add('hidden');
+  document.getElementById(previewSecId)?.classList.add('hidden');
+}

--- a/tests/utils/capacitor.test.js
+++ b/tests/utils/capacitor.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @capacitor/core
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(),
+  },
+}));
+
+import { Capacitor } from '@capacitor/core';
+
+describe('inicializarCapacitor', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('não executa nada quando não está em plataforma nativa', async () => {
+    Capacitor.isNativePlatform.mockReturnValue(false);
+    const { inicializarCapacitor } = await import('../../src/js/utils/capacitor.js');
+    await inicializarCapacitor();
+    // Se não é nativo, não deve tentar importar StatusBar
+    expect(Capacitor.isNativePlatform).toHaveBeenCalled();
+  });
+
+  it('configura StatusBar quando em plataforma nativa', async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    const mockSetStyle = vi.fn().mockResolvedValue(undefined);
+    const mockSetOverlays = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('@capacitor/status-bar', () => ({
+      StatusBar: {
+        setStyle: mockSetStyle,
+        setOverlaysWebView: mockSetOverlays,
+      },
+      Style: { Light: 'LIGHT' },
+    }));
+    const { inicializarCapacitor } = await import('../../src/js/utils/capacitor.js');
+    await inicializarCapacitor();
+    expect(mockSetStyle).toHaveBeenCalledWith({ style: 'LIGHT' });
+    expect(mockSetOverlays).toHaveBeenCalledWith({ overlay: true });
+  });
+
+  it('loga warning quando StatusBar não está disponível', async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    vi.doMock('@capacitor/status-bar', () => {
+      throw new Error('Plugin not installed');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { inicializarCapacitor } = await import('../../src/js/utils/capacitor.js');
+    await inicializarCapacitor();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[Capacitor]'),
+      expect.any(String)
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/utils/importacaoComum.test.js
+++ b/tests/utils/importacaoComum.test.js
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectarFormato,
+  gerarChaveDedupReceita,
+  normalizarValorReceita,
+  resolverContaPorNome,
+  resolverCategoriaPorNome,
+  parsearLinhasReceita,
+} from '../../src/js/utils/importacaoComum.js';
+
+// ── detectarFormato ──────────────────────────────────────────────
+
+describe('detectarFormato', () => {
+  it('detecta CSV', () => {
+    expect(detectarFormato('extrato.csv')).toBe('csv');
+    expect(detectarFormato('FATURA.CSV')).toBe('csv');
+  });
+
+  it('detecta XLSX/XLS', () => {
+    expect(detectarFormato('dados.xlsx')).toBe('xlsx');
+    expect(detectarFormato('dados.xls')).toBe('xlsx');
+    expect(detectarFormato('DADOS.XLSX')).toBe('xlsx');
+  });
+
+  it('detecta PDF', () => {
+    expect(detectarFormato('extrato.pdf')).toBe('pdf');
+    expect(detectarFormato('EXTRATO.PDF')).toBe('pdf');
+  });
+
+  it('retorna null para formato desconhecido', () => {
+    expect(detectarFormato('dados.txt')).toBeNull();
+    expect(detectarFormato('imagem.png')).toBeNull();
+    expect(detectarFormato('')).toBeNull();
+  });
+});
+
+// ── gerarChaveDedupReceita ───────────────────────────────────────
+
+describe('gerarChaveDedupReceita', () => {
+  it('gera chave com prefixo rec||', () => {
+    const chave = gerarChaveDedupReceita(new Date('2026-03-15'), 'Salário março', 8500);
+    expect(chave).toBe('rec||2026-03-15||salário março||8500.00');
+  });
+
+  it('normaliza descrição: lowercase + trim + espaços', () => {
+    const chave = gerarChaveDedupReceita(new Date('2026-01-01'), '  Freelance   Projeto  Web  ', 1200);
+    expect(chave).toBe('rec||2026-01-01||freelance projeto web||1200.00');
+  });
+
+  it('trunca descrição em 60 caracteres', () => {
+    const desc = 'A'.repeat(80);
+    const chave = gerarChaveDedupReceita(new Date('2026-01-01'), desc, 100);
+    expect(chave).toContain('||' + 'a'.repeat(60) + '||');
+  });
+
+  it('aceita data como string ISO', () => {
+    const chave = gerarChaveDedupReceita('2026-06-01', 'Teste', 50);
+    expect(chave).toBe('rec||2026-06-01||teste||50.00');
+  });
+
+  it('retorna null para data ausente', () => {
+    expect(gerarChaveDedupReceita(null, 'Desc', 100)).toBeNull();
+  });
+
+  it('retorna null para valor NaN', () => {
+    expect(gerarChaveDedupReceita(new Date(), 'Desc', NaN)).toBeNull();
+  });
+});
+
+// ── normalizarValorReceita ───────────────────────────────────────
+
+describe('normalizarValorReceita', () => {
+  it('retorna valor absoluto de número positivo', () => {
+    expect(normalizarValorReceita(500)).toBe(500);
+  });
+
+  it('retorna valor absoluto de número negativo', () => {
+    expect(normalizarValorReceita(-350.50)).toBe(350.50);
+  });
+
+  it('parseia string com formato BR: "R$ 1.290,00"', () => {
+    expect(normalizarValorReceita('R$ 1.290,00')).toBe(1290);
+  });
+
+  it('parseia string negativa e retorna absoluto', () => {
+    expect(normalizarValorReceita('-500,00')).toBe(500);
+  });
+
+  it('retorna NaN para null, undefined e string vazia', () => {
+    expect(normalizarValorReceita(null)).toBeNaN();
+    expect(normalizarValorReceita(undefined)).toBeNaN();
+    expect(normalizarValorReceita('')).toBeNaN();
+  });
+
+  it('retorna zero como zero', () => {
+    expect(normalizarValorReceita(0)).toBe(0);
+  });
+});
+
+// ── resolverContaPorNome ─────────────────────────────────────────
+
+describe('resolverContaPorNome', () => {
+  const contas = [
+    { id: 'c1', nome: 'Banco Itaú', emoji: '🏦' },
+    { id: 'c2', nome: 'Nubank',     emoji: '💜' },
+    { id: 'c3', nome: 'Banco BTG',  emoji: '🏦' },
+  ];
+
+  it('resolve por match direto (case-insensitive + sem acento)', () => {
+    expect(resolverContaPorNome('Banco Itaú', contas)).toBe('c1');
+    expect(resolverContaPorNome('banco itau', contas)).toBe('c1');
+  });
+
+  it('resolve por match parcial', () => {
+    expect(resolverContaPorNome('Itaú', contas)).toBe('c1');
+    expect(resolverContaPorNome('nubank', contas)).toBe('c2');
+  });
+
+  it('retorna vazio para nome não encontrado', () => {
+    expect(resolverContaPorNome('Corretora XYZ', contas)).toBe('');
+  });
+
+  it('retorna vazio para entrada vazia ou contas vazias', () => {
+    expect(resolverContaPorNome('', contas)).toBe('');
+    expect(resolverContaPorNome('Itaú', [])).toBe('');
+    expect(resolverContaPorNome(null, contas)).toBe('');
+  });
+});
+
+// ── resolverCategoriaPorNome ─────────────────────────────────────
+
+describe('resolverCategoriaPorNome', () => {
+  const categorias = [
+    { id: 'cat1', nome: 'Salário',      emoji: '💰' },
+    { id: 'cat2', nome: 'Freelance',    emoji: '💻' },
+    { id: 'cat3', nome: 'Rendimentos',  emoji: '📈' },
+  ];
+
+  it('resolve por match direto', () => {
+    expect(resolverCategoriaPorNome('Salário', categorias)).toBe('cat1');
+  });
+
+  it('resolve por match case-insensitive parcial', () => {
+    expect(resolverCategoriaPorNome('freelance', categorias)).toBe('cat2');
+    expect(resolverCategoriaPorNome('Rendimento', categorias)).toBe('cat3');
+  });
+
+  it('retorna vazio para categoria não encontrada', () => {
+    expect(resolverCategoriaPorNome('Investimentos', categorias)).toBe('');
+  });
+
+  it('retorna vazio para entrada vazia', () => {
+    expect(resolverCategoriaPorNome('', categorias)).toBe('');
+    expect(resolverCategoriaPorNome(null, categorias)).toBe('');
+    expect(resolverCategoriaPorNome('Salário', [])).toBe('');
+  });
+});
+
+// ── parsearLinhasReceita ─────────────────────────────────────────
+
+describe('parsearLinhasReceita', () => {
+  const categorias = [
+    { id: 'cat1', nome: 'Salário',   emoji: '💰' },
+    { id: 'cat2', nome: 'Freelance', emoji: '💻' },
+  ];
+  const contas = [
+    { id: 'c1', nome: 'Banco Itaú', emoji: '🏦' },
+  ];
+
+  it('parseia rows com cabeçalho detectado', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor', 'Categoria', 'Conta'],
+      ['15/03/2026', 'Salário março', '8500,00', 'Salário', 'Banco Itaú'],
+      ['20/03/2026', 'Freelance', '1200,00', 'Freelance', ''],
+    ];
+    const result = parsearLinhasReceita(rows, { categorias, contas });
+    expect(result).toHaveLength(2);
+    expect(result[0].descricao).toBe('Salário março');
+    expect(result[0].valor).toBe(8500);
+    expect(result[0].categoriaId).toBe('cat1');
+    expect(result[0].contaId).toBe('c1');
+    expect(result[0].erro).toBeNull();
+    expect(result[1].descricao).toBe('Freelance');
+    expect(result[1].categoriaId).toBe('cat2');
+  });
+
+  it('parseia rows sem cabeçalho (posicionamento padrão)', () => {
+    const rows = [
+      ['Coluna1', 'Coluna2', 'Coluna3'],
+      ['15/03/2026', 'Renda extra', '500,00'],
+    ];
+    const result = parsearLinhasReceita(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].descricao).toBe('Renda extra');
+    expect(result[0].valor).toBe(500);
+  });
+
+  it('marca erros para dados inválidos', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor'],
+      ['', 'Sem data', '100,00'],
+      ['15/03/2026', '', '100,00'],
+      ['15/03/2026', 'Valor zero', '0'],
+    ];
+    const result = parsearLinhasReceita(rows);
+    expect(result[0].erro).toContain('Data inválida');
+    expect(result[1].erro).toContain('Descrição vazia');
+    expect(result[2].erro).toContain('Valor inválido');
+  });
+
+  it('marca duplicatas quando chave existe no Set', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor'],
+      ['15/03/2026', 'Salário', '5000,00'],
+    ];
+    const chave = 'rec||2026-03-15||salário||5000.00';
+    const chavesRec = new Set([chave]);
+    const result = parsearLinhasReceita(rows, { chavesRec });
+    expect(result[0].duplicado).toBe(true);
+  });
+
+  it('não marca duplicata quando chave não existe', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor'],
+      ['15/03/2026', 'Renda nova', '3000,00'],
+    ];
+    const result = parsearLinhasReceita(rows, { chavesRec: new Set() });
+    expect(result[0].duplicado).toBe(false);
+  });
+
+  it('retorna array vazio para input vazio', () => {
+    expect(parsearLinhasReceita([])).toEqual([]);
+  });
+
+  it('pula linhas completamente vazias', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor'],
+      ['', '', ''],
+      ['15/03/2026', 'Teste', '100,00'],
+    ];
+    const result = parsearLinhasReceita(rows);
+    expect(result).toHaveLength(1);
+  });
+
+  it('resolve contaId pelo seletor global quando coluna e inferência falham', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor'],
+      ['15/03/2026', 'Dividendos FII', '300,00'],
+    ];
+    const result = parsearLinhasReceita(rows, { contas: [], contaGlobalId: 'global-1' });
+    expect(result[0].contaId).toBe('global-1');
+  });
+
+  it('gera chave_dedup no formato rec||iso||desc||valor', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor'],
+      ['01/06/2026', 'Aluguel', '2500,00'],
+    ];
+    const result = parsearLinhasReceita(rows);
+    expect(result[0].chave_dedup).toBe('rec||2026-06-01||aluguel||2500.00');
+  });
+
+  it('não gera chave_dedup para linhas com erro', () => {
+    const rows = [
+      ['Data', 'Descricao', 'Valor'],
+      ['', 'Sem data', '100,00'],
+    ];
+    const result = parsearLinhasReceita(rows);
+    expect(result[0].chave_dedup).toBeNull();
+  });
+});


### PR DESCRIPTION
## O que foi feito
- Criado `src/js/utils/importacaoComum.js` como módulo genérico de importação
- Refatorado `receitas.js` — removidas ~200 linhas de código duplicado (parser, normalizadores, helpers de UI)
- Refatorado `importar.js` — removidas ~70 linhas de UI helpers duplicados, usa `lerArquivoXLSX` e `detectarFormato` compartilhados
- 34 testes unitários para `importacaoComum.js`
- 3 testes unitários para `capacitor.js` (dívida técnica da Fase 1 iOS)

## Por que
Eliminação de duplicação de código identificada na issue #96 (TD-006). Ambas as páginas de importação (despesas e receitas) mantinham lógicas paralelas idênticas — `_inferirContaDaDescricao`, `_normalizarValorRec`, `_normalizarDataRec`, `_chaveDedup`, helpers de UI — dificultando manutenção futura e aumentando risco de bugs divergentes.

## Impacto
- **-261 linhas** removidas / **+65 linhas** adicionadas nos arquivos refatorados
- Suite de testes: 194 → **231 testes** (37 novos)
- Build de produção: ✅ sem erros
- Comportamento do app inalterado (refactor interno)

## Como testar
- [ ] `npm test` — deve passar com 231 testes
- [ ] `npm run build` — deve compilar sem erros
- [ ] Testar importação de despesa via CSV/Excel no app local (`npm run dev`)
- [ ] Testar importação de receita via CSV/Excel no app local
- [ ] Verificar que deduplicação funciona igual ao comportamento anterior

## Checklist
- [x] Testes escritos para importacaoComum.js (34 testes)
- [x] Testes escritos para capacitor.js (3 testes)
- [x] Sem secrets ou credenciais no diff
- [x] Regras Firestore não precisam de alteração
- [x] CHANGELOG.md atualizado (v3.20.0)

Fecha: #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)