### PR TITLE
fix(css): navbar responsiva — resolver overflow com 10 links (#129)

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -62,6 +62,9 @@ body {
   color: var(--color-text-muted);
   overflow-x: auto;
   scrollbar-width: none;
+  /* RF-062: fade hint indicando que há mais links à direita */
+  mask-image: linear-gradient(to right, #000 92%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, #000 92%, transparent 100%);
 }
 .navbar-user::-webkit-scrollbar { display: none; }
 
@@ -81,7 +84,7 @@ body {
 .navbar-user a.btn {
   font-size: var(--font-size-sm);
   font-weight: 500;
-  padding: var(--space-1) var(--space-3);
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-md);
   white-space: nowrap;
   transition: background var(--transition), color var(--transition);
@@ -156,6 +159,31 @@ body {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+}
+
+/* RF-062: navbar responsiva — em telas < 1440px, mostra apenas ícones */
+@media (max-width: 1440px) {
+  .navbar-user a.btn .nav-icon { margin-right: 0; }
+  .navbar-user a.btn {
+    font-size: 0;         /* oculta texto */
+    padding: var(--space-1) var(--space-2);
+  }
+  .navbar-user a.btn .nav-icon {
+    width: 18px;
+    height: 18px;
+  }
+  .navbar-user a.btn i[data-lucide] {
+    font-size: var(--font-size-sm);  /* mantém ícone visível */
+  }
+  .navbar-user #btn-logout {
+    font-size: var(--font-size-sm);  /* Sair mantém texto */
+  }
+}
+/* Em telas muito pequenas, oculta nome do usuário */
+@media (max-width: 1024px) {
+  .navbar-user > span#usuario-nome {
+    display: none;
+  }
 }
 
 .brand-icon {


### PR DESCRIPTION
## Summary
- Após RF-062 adicionar o link "Contas" à navbar (10 links no total), em telas menores os últimos links ficavam cortados/inacessíveis
- Reduz padding dos botões, adiciona fade gradient, e usa media queries para mostrar apenas ícones em telas ≤ 1440px
- Oculta nome do usuário em telas ≤ 1024px

## Mudanças
- `src/css/components.css`: padding reduzido, mask-image fade, 2 media queries responsivas

## Test plan
- [ ] Verificar navbar em tela ≥ 1440px: todos os 10 links visíveis com texto
- [ ] Verificar navbar em tela < 1440px: apenas ícones visíveis, todos clicáveis
- [ ] Verificar navbar em tela < 1024px: nome do usuário oculto
- [ ] Verificar que o botão "Sair" mantém texto visível em todas as resoluções
- [ ] Testar scroll horizontal da navbar em telas muito estreitas

🤖 Generated with [Claude Code](https://claude.com/claude-code)