### PR TITLE
fix(importar): escHTML em membroNome — XSS no badge RF-063

### DIFF
--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -742,7 +742,7 @@ function renderizarPreview() {
     } else if (l._transferenciaInterna) {
       // RF-063: badge de transferência interna detectada
       const dir = l._transferenciaInterna.direcao === 'recebida' ? '📥' : '📤';
-      tdStatus.innerHTML = '<span class="imp-badge imp-badge--ok" style="background:#dbeafe;color:#1e40af;" title="Transferência interna detectada (' + l._transferenciaInterna.membroNome + ')' + chaveInfo + '">' + dir + ' 🔁 Transf.</span>';
+      tdStatus.innerHTML = '<span class="imp-badge imp-badge--ok" style="background:#dbeafe;color:#1e40af;" title="Transferência interna detectada (' + escHTML(l._transferenciaInterna.membroNome) + ')' + chaveInfo + '">' + dir + ' 🔁 Transf.</span>';
       tr.classList.add('imp-row-transf');
     } else if (l.tipoLinha === 'receita') {
       // NRF-006: modo banco — badge de receita


### PR DESCRIPTION
## Summary
- Corrige XSS em `importar.js:745`: `l._transferenciaInterna.membroNome` era inserido via `innerHTML` no atributo `title` sem sanitização
- Um nome de membro malicioso (ex: `Luigi" onclick="alert(1)`) poderia escapar o atributo e injetar HTML/JS arbitrário
- Fix: envolver com `escHTML()` que já estava importado no arquivo

## Root cause
RF-063 introduziu o badge de transferência interna com o nome do membro no `title`, mas omitiu o `escHTML()` que é obrigatório para todo dado de usuário inserido via `innerHTML`.

## Test plan
- [x] `npm test` — 284/284 passando
- [x] `escHTML` já importado de `../utils/formatters.js`
- [x] Nenhuma alteração de comportamento — apenas sanitização do atributo

🤖 Generated with [Claude Code](https://claude.com/claude-code)