### PR TITLE
test(utils): testes para skeletons.js — 31 TCs (v3.23.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.23.4] - 2026-04-14
+
+### Testes
+
+- **Tech debt — skeletons.js:** 31 novos testes unitários para os 4 geradores de HTML do módulo `src/js/utils/skeletons.js`.
+  - `skeletonCards` (10 TCs): count=0, count=1, count=5, count=10, ciclo de 5 larguras, skeleton-circle/amount por card.
+  - `skeletonTableRows` (8 TCs): count=0, defaults, linhas e colunas corretas, skeleton-line por célula, margin:0.
+  - `emptyStateHTML` (7 TCs): inclusão de ícone/título/hint, omissão de hint quando vazio/ausente, classes CSS.
+  - `errorStateHTML` (6 TCs): título/hint, classe error-state, botão retry, classes CSS.
+  - Suite total: **501 testes** (19 arquivos). Antes: 470 (18 arquivos).
+
+---
+
 ## [3.23.3] - 2026-04-13
 
 ### Testes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.23.3",
+  "version": "3.23.4",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/tests/utils/skeletons.test.js
+++ b/tests/utils/skeletons.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  skeletonCards,
+  skeletonTableRows,
+  emptyStateHTML,
+  errorStateHTML,
+} from '../../src/js/utils/skeletons.js';
+
+// ============================================================
+// skeletons.test.js — 22 TCs
+// Módulo: src/js/utils/skeletons.js
+// Cobertura: skeletonCards, skeletonTableRows, emptyStateHTML, errorStateHTML
+// ============================================================
+
+describe('skeletonCards', () => {
+  it('retorna string vazia para count=0', () => {
+    expect(skeletonCards(0)).toBe('');
+  });
+
+  it('gera 1 card com count=1', () => {
+    const html = skeletonCards(1);
+    const matches = html.match(/class="skeleton-item"/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it('gera 5 cards com count=5 (default)', () => {
+    const html = skeletonCards(5);
+    const matches = html.match(/class="skeleton-item"/g);
+    expect(matches).toHaveLength(5);
+  });
+
+  it('gera 10 cards com count=10', () => {
+    const html = skeletonCards(10);
+    const matches = html.match(/class="skeleton-item"/g);
+    expect(matches).toHaveLength(10);
+  });
+
+  it('cada card contém skeleton-circle', () => {
+    const html = skeletonCards(3);
+    const matches = html.match(/class="skeleton skeleton-circle"/g);
+    expect(matches).toHaveLength(3);
+  });
+
+  it('cada card contém skeleton-amount', () => {
+    const html = skeletonCards(3);
+    const matches = html.match(/class="skeleton skeleton-amount"/g);
+    expect(matches).toHaveLength(3);
+  });
+
+  it('primeiro card usa largura 70%', () => {
+    const html = skeletonCards(1);
+    expect(html).toContain('width:70%');
+  });
+
+  it('cicla as 5 larguras corretamente', () => {
+    const html = skeletonCards(5);
+    expect(html).toContain('width:70%');
+    expect(html).toContain('width:55%');
+    expect(html).toContain('width:80%');
+    expect(html).toContain('width:60%');
+    expect(html).toContain('width:75%');
+  });
+
+  it('cicla larguras a partir do índice 5 (volta ao início)', () => {
+    const html = skeletonCards(6);
+    // 6º item → widths[0] = 70%
+    const first70 = html.indexOf('width:70%');
+    const second70 = html.indexOf('width:70%', first70 + 1);
+    expect(second70).toBeGreaterThan(first70);
+  });
+
+  it('retorna string (não null/undefined)', () => {
+    expect(typeof skeletonCards()).toBe('string');
+  });
+});
+
+describe('skeletonTableRows', () => {
+  it('retorna string vazia para count=0', () => {
+    expect(skeletonTableRows(0)).toBe('');
+  });
+
+  it('gera 1 linha com count=1', () => {
+    const html = skeletonTableRows(1, 3);
+    const rows = html.match(/<tr>/g);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('gera 6 linhas com defaults (count=6, cols=7)', () => {
+    const html = skeletonTableRows();
+    const rows = html.match(/<tr>/g);
+    expect(rows).toHaveLength(6);
+  });
+
+  it('cada linha fecha com </tr>', () => {
+    const html = skeletonTableRows(3, 2);
+    const rows = html.match(/<\/tr>/g);
+    expect(rows).toHaveLength(3);
+  });
+
+  it('cada linha tem o número correto de colunas', () => {
+    const html = skeletonTableRows(2, 4);
+    const tds = html.match(/<td>/g);
+    expect(tds).toHaveLength(8); // 2 rows × 4 cols
+  });
+
+  it('cada célula contém skeleton-line', () => {
+    const html = skeletonTableRows(1, 3);
+    const lines = html.match(/class="skeleton skeleton-line"/g);
+    expect(lines).toHaveLength(3);
+  });
+
+  it('cada célula tem margin:0', () => {
+    const html = skeletonTableRows(1, 2);
+    const margins = html.match(/margin:0/g);
+    expect(margins).toHaveLength(2);
+  });
+
+  it('retorna string para count=6 (default)', () => {
+    expect(typeof skeletonTableRows()).toBe('string');
+  });
+});
+
+describe('emptyStateHTML', () => {
+  it('inclui o ícone passado', () => {
+    const html = emptyStateHTML('📭', 'Nenhuma despesa', '');
+    expect(html).toContain('📭');
+  });
+
+  it('inclui o título passado', () => {
+    const html = emptyStateHTML('💡', 'Sem dados', '');
+    expect(html).toContain('Sem dados');
+  });
+
+  it('inclui o hint quando fornecido', () => {
+    const html = emptyStateHTML('📭', 'Vazio', 'Adicione uma despesa');
+    expect(html).toContain('Adicione uma despesa');
+    expect(html).toContain('empty-state__hint');
+  });
+
+  it('omite o bloco hint quando hint é vazio string', () => {
+    const html = emptyStateHTML('📭', 'Vazio', '');
+    expect(html).not.toContain('empty-state__hint');
+  });
+
+  it('omite o bloco hint quando hint não é fornecido', () => {
+    const html = emptyStateHTML('📭', 'Vazio');
+    expect(html).not.toContain('empty-state__hint');
+  });
+
+  it('contém classe empty-state', () => {
+    const html = emptyStateHTML('🎉', 'OK');
+    expect(html).toContain('class="empty-state"');
+  });
+
+  it('contém classe empty-state__title', () => {
+    const html = emptyStateHTML('🎉', 'OK');
+    expect(html).toContain('empty-state__title');
+  });
+});
+
+describe('errorStateHTML', () => {
+  it('inclui o título do erro', () => {
+    const html = errorStateHTML('Erro ao carregar', 'Tente novamente');
+    expect(html).toContain('Erro ao carregar');
+  });
+
+  it('inclui o hint do erro', () => {
+    const html = errorStateHTML('Falha', 'Verifique sua conexão');
+    expect(html).toContain('Verifique sua conexão');
+  });
+
+  it('contém classe error-state', () => {
+    const html = errorStateHTML('Erro', 'Dica');
+    expect(html).toContain('class="error-state"');
+  });
+
+  it('contém botão de retry', () => {
+    const html = errorStateHTML('Erro', 'Dica');
+    expect(html).toContain('error-retry');
+    expect(html).toContain('Tentar novamente');
+  });
+
+  it('contém classe error-state__title', () => {
+    const html = errorStateHTML('Título', 'Hint');
+    expect(html).toContain('error-state__title');
+  });
+
+  it('contém classe error-state__hint', () => {
+    const html = errorStateHTML('Título', 'Hint');
+    expect(html).toContain('error-state__hint');
+  });
+});


### PR DESCRIPTION
## O que foi feito

- Adicionado `tests/utils/skeletons.test.js` com 31 TCs cobrindo todos os 4 exports de `src/js/utils/skeletons.js`
- `skeletonCards` (10 TCs): count=0/1/5/10, ciclo de 5 larguras, classes skeleton-circle e skeleton-amount
- `skeletonTableRows` (8 TCs): count=0, defaults (6 rows × 7 cols), total de `<td>`, skeleton-line por célula, margin:0
- `emptyStateHTML` (7 TCs): inclusão de ícone/título/hint, omissão de hint quando vazio ou omitido, classes CSS
- `errorStateHTML` (6 TCs): título, hint, classe error-state, botão error-retry, classes CSS
- Atualizado `package.json` para v3.23.4
- Atualizado `CHANGELOG.md`

## Subagentes

- test-runner: PASS — 501 testes (19 arquivos), 0 falhas
- security-reviewer: N/A — sem mudanças em auth/database/innerHTML com dados de usuário
- import-pipeline-reviewer: N/A — sem mudanças no pipeline de importação

## Testar

- [x] npm test (501 passando)
- [x] npm run build

## Checklist

- [x] Sem credenciais Firebase
- [x] CHANGELOG.md atualizado
- [x] CSS usa variáveis (N/A — sem CSS)
- [x] chave_dedup intacta (N/A — sem mudanças no pipeline)