### PR TITLE
fix(importar): header loop limit 10->15 para suporte BTG XLS - BUG-028 fix real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.23.7] - 2026-04-14
+
+### Corrigido
+
+- **BUG-028 (fix real): Loop de header detection limitado a 10 linhas:** o loop `for (i < Math.min(rows.length, 10))` verificava índices 0–9, mas o BTG XLS tem o header exatamente no índice 10 (após 10 linhas de metadata). Resultado: `headerIdx = -1` → todos os erros "Data inválida, Valor inválido" persistiam mesmo após o fix do PR #143. Fix: limite ampliado para 15 linhas em `normalizadorTransacoes.js` e `detectorOrigemArquivo.js`. 1 novo TC com estrutura real BTG (10 linhas de metadata + header no índice 10 + transação). 509 testes passando.
+
 ## [3.23.6] - 2026-04-14
 
 ### Corrigido

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 - **Usuários:** Luigi + Ana (casal)
 - **Dev:** Luigi (solo developer)
-- **Versão atual:** v3.23.6
+- **Versão atual:** v3.23.7
 - **Repo:** https://github.com/luigifilippozzi-cmyk/minhas-financas
 - **Stack:** HTML5 · CSS3 · JS ES6+ · **Vite 5** (bundler MPA) · **Capacitor 8** (iOS) · Firebase Auth · Cloud Firestore (via npm) · Chart.js v4 · SheetJS (XLSX)
 
@@ -20,7 +20,7 @@
 npm run dev                 # Vite dev server (HMR, hot reload)
 npm run build               # Vite build → dist/ (produção)
 npm run preview             # Preview do build de produção
-npm test                    # Vitest — roda suite de 508 testes unitários
+npm test                    # Vitest — roda suite de 509 testes unitários
 npm run test:watch          # Vitest em modo watch
 npm run test:coverage       # Coverage com V8
 npm run test:integration    # Testes de integração (requer Firebase Emulator)
@@ -187,7 +187,7 @@ Todas as cores, sombras e fontes estão em `variables.css` como CSS custom prope
 
 - Framework: **Vitest** com `@vitest/coverage-v8`
 - Localização: `tests/` (espelho de `src/js/utils/` e `src/js/services/`)
-- **508 testes unitários** cobrindo: parsers, dedup, ajusteDetector, normalizador, pipelineCartao, importarDedup, detectorTransferenciaInterna, reconciliadorFatura, bankFingerprintMap, detectorOrigemArquivo, recurringDetector, pdfParser, skeletons
+- **509 testes unitários** cobrindo: parsers, dedup, ajusteDetector, normalizador, pipelineCartao, importarDedup, detectorTransferenciaInterna, reconciliadorFatura, bankFingerprintMap, detectorOrigemArquivo, recurringDetector, pdfParser, skeletons
 - **26 testes de integração** (Firebase Emulator): regras Firestore, CRUD despesas, purge em lote
 - **Rodar antes de qualquer commit:** `npm test`
 - Testes de integração: `npm run test:integration` (requer emulador na porta 8080)
@@ -214,7 +214,7 @@ Todas as cores, sombras e fontes estão em `variables.css` como CSS custom prope
 Luigi (Product Owner)
   ├── PM Agent          → Relatório diário, métricas, alertas (read-only)
   └── Dev Manager       → Executor de código, orquestrador de subagentes
-        ├── test-runner              → Vitest (508 testes) + coverage
+        ├── test-runner              → Vitest (509 testes) + coverage
         ├── security-reviewer        → Firestore rules, escHTML/XSS, auth
         └── import-pipeline-reviewer → Pipeline de importação (parser, dedup, ajuste)
 ```
@@ -263,7 +263,7 @@ git checkout -b feat/MF-{issue}-{descricao-kebab}   # ou fix/MF-{issue}-...
 # 3. Implementar (seguir padrões deste CLAUDE.md)
 
 # 4. Testar — OBRIGATÓRIO antes de commit
-npm test                    # 508 testes devem passar
+npm test                    # 509 testes devem passar
 
 # 5. Acionar subagentes (ver AGENTS.md §6)
 #    - test-runner: SEMPRE antes de PR

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.23.6",
+  "version": "3.23.7",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/src/js/utils/detectorOrigemArquivo.js
+++ b/src/js/utils/detectorOrigemArquivo.js
@@ -52,10 +52,12 @@ function _detectarTipo(rows, textLines) {
   const norm = s => String(s ?? '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim();
 
   // 1. Analisa estrutura das colunas (CSV/XLSX)
-  for (let i = 0; i < Math.min(rows.length, 5); i++) {
+  // BUG-028: BTG XLS tem 10 linhas de metadata antes do header → buscar até linha 15
+  for (let i = 0; i < Math.min(rows.length, 15); i++) {
     const h     = rows[i].map(norm);
     const hOrig = rows[i].map(c => String(c ?? '').trim()).filter(Boolean);
-    const temData      = h.some(c => c === 'data');
+    // BUG-028: BTG usa "Data e hora" em vez de "data"
+    const temData      = h.some(c => c === 'data' || c === 'data e hora');
     const temValor     = h.some(c => c === 'valor' || c.startsWith('valor'));
     if (!temData || !temValor) continue;
     const temPortador  = h.some(c => c.includes('portador') || c.includes('titular'));

--- a/src/js/utils/normalizadorTransacoes.js
+++ b/src/js/utils/normalizadorTransacoes.js
@@ -45,7 +45,8 @@ export function parsearLinhasCSVXLSX(rows, {
 } = {}) {
   if (!rows.length) return [];
   let headerIdx = -1;
-  for (let i = 0; i < Math.min(rows.length, 10); i++) {
+  // BUG-028: BTG XLS tem 10 linhas de metadata antes do header → buscar até linha 15
+  for (let i = 0; i < Math.min(rows.length, 15); i++) {
     const r = rows[i].map(c => String(c ?? '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim());
     if (r.some(c => c === 'data' || c === 'data e hora') &&
         r.some(c => c.includes('estabelecimento') || c.includes('descri') || c === 'historico') &&

--- a/tests/utils/normalizadorTransacoes.test.js
+++ b/tests/utils/normalizadorTransacoes.test.js
@@ -376,6 +376,32 @@ describe('parsearLinhasCSVXLSX', () => {
 
   // BUG-028: Suporte a extratos BTG XLS com header "Data e hora"
   describe('BTG XLS extrato — BUG-028', () => {
+    it('BUG-028: header na linha 10 (estrutura real BTG com 10 linhas de metadata)', () => {
+      // Simula exatamente o BTG XLS: 10 linhas de metadata, header no índice 10
+      // O loop antigo (i < 10) nunca alcançava o índice 10 → headerIdx = -1 → todos os erros
+      const rows = [
+        ['', 'Extrato de conta corrente', '', '', '', '', '', '', '', '46125', ''], // row 0
+        ['', '', '', '', '', '', '', '', '', '', ''],                               // row 1
+        ['', 'Cliente:', 'Luigi Cassab Filippozzi', '', '', '', '', '', '', '', ''], // row 2
+        ['', 'CPF:', '344.482.858-63', '', '', '', '', '', '', '', ''],             // row 3
+        ['', 'Agência:', '20', '', '', '', '', '', '', '', ''],                     // row 4
+        ['', 'Conta:', '903955-0', '', '', '', '', '', '', '', ''],                 // row 5
+        ['', 'Período do extrato:', '30/03/2026 a 13/04/2026', '', '', '', '', '', '', '', ''], // row 6
+        ['', '', '', '', '', '', '', '', '', '', ''],                               // row 7
+        ['', 'Lançamentos:', '', '', '', '', '', 'Saldo atual:', '', '8821.19', ''], // row 8
+        ['', '', '', '', '', '', '', '', '', '', ''],                               // row 9
+        ['', 'Data e hora', 'Categoria', 'Transação', '', '', 'Descrição', '', '', '', 'Valor'], // row 10: HEADER
+        ['', '30/03/2026 18:43', 'Alimentação', 'Compra no débito', '', '', 'Art Lanches', '', '', '', '-19.0'], // row 11
+      ];
+      const resultado = parsearLinhasCSVXLSX(rows);
+      expect(resultado).toHaveLength(1);
+      const linha = resultado[0];
+      expect(linha.erro).toBeNull();
+      expect(linha.descricao).toBe('Art Lanches');
+      expect(linha.valor).toBe(19);
+      expect(linha.data).toBeInstanceOf(Date);
+    });
+
     it('detecta header "Data e hora" como coluna de data (startsWith)', () => {
       const rows = [
         ['', 'Data e hora', 'Categoria', 'Transação', '', '', 'Descrição', '', '', '', 'Valor'],


### PR DESCRIPTION
Root cause real do BUG-028: loop buscava header em i<10 (indices 0-9), BTG tem header no indice 10. Fix: limite 15 em normalizadorTransacoes.js e detectorOrigemArquivo.js. +1 TC com 10 linhas de metadata reais. 509 testes.