### PR TITLE
fix(importar): arrays sparse SheetJS + BTG classificado como receita - BUG-028b (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.23.8] - 2026-04-14
+
+### Corrigido
+
+- **BUG-028b: Arrays sparse do SheetJS causavam crash "Cannot read properties of undefined (reading 'includes')":** SheetJS 0.18.5 retorna arrays sparse (holes `undefined` reais) ao ler XLS. `Array.prototype.map` pula holes, gerando arrays com `undefined` nas posições vazias. `findIndex` visitava esses `undefined` e chamava `undefined.includes()` → TypeError. Fix: substituído `rows[i].map(...)` por `Array.from(rows[i], c => ...)` em `normalizadorTransacoes.js` e `detectorOrigemArquivo.js` — `Array.from` converte holes em `undefined` explícito e o mapper transforma via `String(c ?? '')`.
+- **BUG-028b: BTG XLS classificado incorretamente como "receita":** BTG extrato bancário tem coluna "Categoria" (para classificar lançamentos). `_detectarTipo` detectava `temCategoria && !temPortador && !temParcela` e retornava `'receita'`. Fix: adicionada condição `!temDataEHora` — extrato bancário usa "Data e hora", template de receitas usa "Data". 5 novos TCs (3 em normalizadorTransacoes, 3 em detectorOrigemArquivo).
+
 ## [3.23.7] - 2026-04-14
 
 ### Corrigido

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 - **Usuários:** Luigi + Ana (casal)
 - **Dev:** Luigi (solo developer)
-- **Versão atual:** v3.23.7
+- **Versão atual:** v3.23.8
 - **Repo:** https://github.com/luigifilippozzi-cmyk/minhas-financas
 - **Stack:** HTML5 · CSS3 · JS ES6+ · **Vite 5** (bundler MPA) · **Capacitor 8** (iOS) · Firebase Auth · Cloud Firestore (via npm) · Chart.js v4 · SheetJS (XLSX)
 

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -70,6 +70,62 @@ Usuários do BTG conseguem importar extratos bancários normalmente. Dados reais
 
 ---
 
+### BUG-028b — Arrays sparse do SheetJS causam crash + BTG classificado como "receita"
+**Severidade:** 🔴 Crítico
+**Versão introduzida:** v3.23.7 (fix parcial do BUG-028 expôs o bug)
+**Versão corrigida:** v3.23.8
+**Arquivos:** `src/js/utils/normalizadorTransacoes.js`, `src/js/utils/detectorOrigemArquivo.js`
+**Descoberto em:** QA BTG import — 2026-04-14
+
+**Descrição do problema (dois bugs simultâneos):**
+
+**Bug 1 — Crash TypeError:** Com o loop do BUG-028 corrigido para alcançar o índice 10, o código chegava ao header BTG. Porém `rows[10].map(c => String(c ?? '').trim())` gerava um array ainda sparse (porque `Array.prototype.map` pula holes — `undefined` real de array sparse do SheetJS permanecia como hole no array resultante). Em seguida, `h.findIndex(c => c.includes('valor'))` visitava os holes como `undefined` → `undefined.includes('valor')` → `TypeError: Cannot read properties of undefined (reading 'includes')`.
+
+**Bug 2 — Classificação errada:** `_detectarTipo` no `detectorOrigemArquivo.js` usava a regra `temCategoria && !temPortador && !temParcela → tipo: 'receita'`. O BTG extrato bancário tem coluna "Categoria" (para categorizar lançamentos). Resultado: arquivo de extrato bancário era classificado como `'receita'` → pipeline errado, nenhuma transação processada como despesa/banco.
+
+**Root causes:**
+
+1. **SheetJS 0.18.5 retorna arrays sparse** ao ler XLS com células vazias. O XLSX `.sheet_to_json({header:1})` usa `null` para células `null` em alguns casos, mas **holes** (`undefined` real) para células totalmente ausentes no arquivo. `Array.prototype.map` pula holes → o resultado também é sparse → `findIndex` chama callback em posições `undefined`.
+
+2. **Regra de detecção de receita muito ampla:** `temCategoria && !temPortador && !temParcela` não distinguia extrato bancário BTG de template de receitas. A coluna "Data e hora" (presente apenas em extratos BTG) é o discriminador correto.
+
+**Correção aplicada:**
+
+1. **`normalizadorTransacoes.js`** — substituído `.map(...)` por `Array.from(row, c => ...)` em todos os pontos de processamento do header BTG. `Array.from` converte holes em `undefined` explícito e o mapper transforma via `String(c ?? '')`.
+
+```javascript
+// ANTES (quebrado com arrays sparse):
+const r = rows[i].map(c => String(c ?? '').toLowerCase()...);
+const h = rows[headerIdx].map(c => String(c ?? '')...);
+
+// DEPOIS (Array.from trata holes):
+const r = Array.from(rows[i], c => String(c ?? '').toLowerCase()...);
+const h = Array.from(rows[headerIdx], c => String(c ?? '')...);
+```
+
+2. **`detectorOrigemArquivo.js`** — idem `Array.from` + regra de receita refinada com `!temDataEHora`:
+
+```javascript
+// ANTES:
+if (temCategoria && !temPortador && !temParcela) return { tipo: 'receita', ... };
+
+// DEPOIS:
+const temDataEHora = h.some(c => c === 'data e hora');
+if (temCategoria && !temPortador && !temParcela && !temDataEHora) return { tipo: 'receita', ... };
+```
+
+**Testes adicionados:** 5 novos TCs (3 em `normalizadorTransacoes.test.js` + 3 em `detectorOrigemArquivo.test.js`):
+- Array sparse com header na linha 0 não causa crash
+- Array sparse com header na linha 10 (estrutura completa real BTG) retorna 2 transações válidas
+- BTG com "Data e hora" + "Categoria" → `tipo: 'banco'` (não `'receita'`)
+- Arquivo de receitas com "Data" + "Categoria" continua → `tipo: 'receita'`
+- Array sparse no detector não causa crash
+
+**Impacto:**
+Importação BTG XLS agora funciona end-to-end: sem crash, sem classificação errada, transações corretamente parseadas como extrato bancário.
+
+---
+
 ## Bugs Corrigidos
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.23.7",
+  "version": "3.23.8",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/src/js/utils/detectorOrigemArquivo.js
+++ b/src/js/utils/detectorOrigemArquivo.js
@@ -53,9 +53,10 @@ function _detectarTipo(rows, textLines) {
 
   // 1. Analisa estrutura das colunas (CSV/XLSX)
   // BUG-028: BTG XLS tem 10 linhas de metadata antes do header → buscar até linha 15
+  // BUG-028b: SheetJS retorna arrays sparse → usar Array.from() para converter holes em ''
   for (let i = 0; i < Math.min(rows.length, 15); i++) {
-    const h     = rows[i].map(norm);
-    const hOrig = rows[i].map(c => String(c ?? '').trim()).filter(Boolean);
+    const h     = Array.from(rows[i], norm);
+    const hOrig = Array.from(rows[i], c => String(c ?? '').trim()).filter(Boolean);
     // BUG-028: BTG usa "Data e hora" em vez de "data"
     const temData      = h.some(c => c === 'data' || c === 'data e hora');
     const temValor     = h.some(c => c === 'valor' || c.startsWith('valor'));
@@ -63,15 +64,18 @@ function _detectarTipo(rows, textLines) {
     const temPortador  = h.some(c => c.includes('portador') || c.includes('titular'));
     const temParcela   = h.some(c => c === 'parcela');
     const temCategoria = h.some(c => c.startsWith('categor'));
-    if (temPortador && temParcela)                   return { tipo: 'cartao',  confianca: 'alta',  confiancaNum: 90, colunas: hOrig };
-    if (temCategoria && !temPortador && !temParcela) return { tipo: 'receita', confianca: 'alta',  confiancaNum: 90, colunas: hOrig };
+    // BUG-028b: BTG extrato bancário tem coluna "Categoria" mas usa "Data e hora" (não "Data").
+    // Extrato bancário com "Data e hora" nunca é um arquivo de receitas.
+    const temDataEHora = h.some(c => c === 'data e hora');
+    if (temPortador && temParcela)                               return { tipo: 'cartao',  confianca: 'alta',  confiancaNum: 90, colunas: hOrig };
+    if (temCategoria && !temPortador && !temParcela && !temDataEHora) return { tipo: 'receita', confianca: 'alta',  confiancaNum: 90, colunas: hOrig };
     // RF-024: template padrão de extrato — exatamente 3 colunas (Data, Descrição, Valor)
     // Sem portador/parcela/categoria → extrato bancário com sinal do valor determinando tipo
     if (!temPortador && !temParcela && !temCategoria && hOrig.length === 3 &&
         temData && h.some(c => c.includes('descri')) && temValor) {
       return { tipo: 'banco', confianca: 'alta', confiancaNum: 90, colunas: hOrig };
     }
-    if (!temPortador && !temParcela)                 return { tipo: 'banco',   confianca: 'baixa', confiancaNum: 60, colunas: hOrig };
+    if (!temPortador && !temParcela)                             return { tipo: 'banco',   confianca: 'baixa', confiancaNum: 60, colunas: hOrig };
     return { tipo: 'despesa', confianca: 'baixa', confiancaNum: 50, colunas: hOrig };
   }
 

--- a/src/js/utils/normalizadorTransacoes.js
+++ b/src/js/utils/normalizadorTransacoes.js
@@ -46,8 +46,10 @@ export function parsearLinhasCSVXLSX(rows, {
   if (!rows.length) return [];
   let headerIdx = -1;
   // BUG-028: BTG XLS tem 10 linhas de metadata antes do header → buscar até linha 15
+  // BUG-028b: SheetJS retorna arrays sparse (holes são undefined, não null).
+  //   Array.from() converte holes em undefined explícito → map/findIndex funcionam corretamente.
   for (let i = 0; i < Math.min(rows.length, 15); i++) {
-    const r = rows[i].map(c => String(c ?? '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim());
+    const r = Array.from(rows[i], c => String(c ?? '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim());
     if (r.some(c => c === 'data' || c === 'data e hora') &&
         r.some(c => c.includes('estabelecimento') || c.includes('descri') || c === 'historico') &&
         r.some(c => c.includes('valor') || c.includes('credito') || c.includes('debito'))) {
@@ -61,7 +63,8 @@ export function parsearLinhasCSVXLSX(rows, {
   let idxData = 0, idxEstab = 1, idxPortador = 2, idxValor = 3, idxParcela = 4, idxConta = -1;
   let idxCredito = -1, idxDebito = -1;
   if (headerIdx >= 0) {
-    const h = rows[headerIdx].map(c => String(c ?? '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim());
+    // BUG-028b: Array.from() para converter array sparse do SheetJS em dense
+    const h = Array.from(rows[headerIdx], c => String(c ?? '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim());
     idxData     = h.findIndex(c => c === 'data' || c === 'data e hora');
     idxEstab    = h.findIndex(c => c.includes('estabelecimento') || c.includes('descri') || c === 'historico');
     idxPortador = h.findIndex(c => c.includes('portador') || c.includes('titular'));

--- a/tests/utils/detectorOrigemArquivo.test.js
+++ b/tests/utils/detectorOrigemArquivo.test.js
@@ -83,6 +83,35 @@ describe('detectarOrigemArquivo — tipo por colunas CSV', () => {
     expect(r.confiancaTipo).toBe(30);
     expect(r.colunas).toEqual([]);
   });
+
+  it('BUG-028b: BTG XLS com "Data e hora" e coluna "Categoria" é detectado como banco, não receita', () => {
+    // BTG extrato bancário tem coluna "Categoria" (BUG-028b: detector classificava como 'receita')
+    // Distinção: extrato bancário usa "Data e hora"; template de receitas usa "Data"
+    const rows = [
+      [null, 'Data e hora', 'Categoria', 'Transação', null, null, 'Descrição', null, null, null, 'Valor'],
+    ];
+    const r = detectarOrigemArquivo({ fileName: 'Extrato_BTG.xls', rows });
+    expect(r.tipo).toBe('banco');
+    expect(r.pipeline).toBe('PIPELINE_BANCARIO');
+  });
+
+  it('BUG-028b: arquivo de receitas com "Data" e "Categoria" continua sendo detectado como receita', () => {
+    // Garante que a correção do BTG não quebra detecção de arquivos de receitas legítimos
+    const rows = [['Data', 'Descrição', 'Valor', 'Categoria']];
+    const r = detectarOrigemArquivo({ fileName: 'receitas.csv', rows });
+    expect(r.tipo).toBe('receita');
+  });
+
+  it('BUG-028b: arrays sparse do SheetJS não causam crash no detector', () => {
+    // SheetJS retorna holes undefined em arrays sparse → Array.from() necessário
+    const mkSparse = (obj, len) => Object.assign(new Array(len), obj);
+    const rows = [
+      mkSparse({ 1: 'Data e hora', 2: 'Categoria', 3: 'Transação', 6: 'Descrição', 10: 'Valor' }, 11),
+    ];
+    expect(() => detectarOrigemArquivo({ fileName: 'Extrato_BTG.xls', rows })).not.toThrow();
+    const r = detectarOrigemArquivo({ fileName: 'Extrato_BTG.xls', rows });
+    expect(r.tipo).toBe('banco');
+  });
 });
 
 // ── Detecção de tipo (PDF textLines) ─────────────────────────────────────────

--- a/tests/utils/normalizadorTransacoes.test.js
+++ b/tests/utils/normalizadorTransacoes.test.js
@@ -498,5 +498,56 @@ describe('parsearLinhasCSVXLSX', () => {
       expect(resultado.map(r => r.descricao)).toEqual(['Art Lanches', 'Pagamento recebido']);
       expect(resultado.every(r => r.erro === null)).toBe(true);
     });
+
+    it('BUG-028b: arrays sparse do SheetJS (holes undefined) não causam crash no findIndex', () => {
+      // SheetJS 0.18.5 retorna arrays sparse quando células estão vazias:
+      // holes são undefined reais, não null. Array.prototype.map pula holes, mas
+      // findIndex visita holes como undefined → undefined.includes() lançava TypeError.
+      // Fix: usar Array.from() antes de map/findIndex para converter holes em ''.
+      const sparseHeader = Object.assign(new Array(11), {
+        1: 'Data e hora', 2: 'Categoria', 3: 'Transação', 6: 'Descrição', 10: 'Valor',
+      }); // indices 0,4,5,7,8,9 são holes (undefined)
+      const sparseRow = Object.assign(new Array(11), {
+        1: '30/03/2026 18:43', 2: 'Alimentação', 3: 'Compra', 6: 'Art Lanches', 10: '-19.0',
+      });
+      const rows = [
+        sparseHeader, // row 0: header (sparse)
+        sparseRow,    // row 1: transação (sparse)
+      ];
+      // Não deve lançar TypeError: Cannot read properties of undefined (reading 'includes')
+      expect(() => parsearLinhasCSVXLSX(rows)).not.toThrow();
+      const resultado = parsearLinhasCSVXLSX(rows);
+      expect(resultado).toHaveLength(1);
+      expect(resultado[0].erro).toBeNull();
+      expect(resultado[0].descricao).toBe('Art Lanches');
+    });
+
+    it('BUG-028b: arrays sparse com header na linha 10 (estrutura completa BTG real)', () => {
+      // Reproduz exatamente a estrutura do arquivo real: rows[i] são sparse (SheetJS)
+      const mkSparse = (obj, len) => Object.assign(new Array(len), obj);
+      const rows = [
+        mkSparse({ 1: 'Extrato de conta corrente', 9: '13/04/2026' }, 11), // row 0
+        new Array(11),                                                       // row 1 (vazia)
+        mkSparse({ 1: 'Cliente:', 2: 'Luigi Filippozzi' }, 11),             // row 2
+        mkSparse({ 1: 'CPF:', 2: '344.482.858-63' }, 11),                   // row 3
+        mkSparse({ 1: 'Agência:', 2: '20' }, 11),                           // row 4
+        mkSparse({ 1: 'Conta:', 2: '903955-0' }, 11),                       // row 5
+        mkSparse({ 1: 'Período do extrato:', 2: '30/03/2026 a 13/04/2026' }, 11), // row 6
+        new Array(11),                                                       // row 7 (vazia)
+        mkSparse({ 1: 'Lançamentos:', 7: 'Saldo atual:', 9: '8,821.19' }, 11), // row 8
+        new Array(11),                                                       // row 9 (vazia)
+        mkSparse({ 1: 'Data e hora', 2: 'Categoria', 3: 'Transação', 6: 'Descrição', 10: 'Valor' }, 11), // row 10: HEADER
+        mkSparse({ 1: '30/03/2026 18:43', 2: 'Alimentação', 3: 'Compra no débito', 6: 'Art Lanches', 10: '-19.00' }, 11), // row 11
+        mkSparse({ 1: '30/03/2026 23:59', 6: 'Saldo Diário', 10: '163.55' }, 11), // row 12: Saldo Diário
+        mkSparse({ 1: '31/03/2026 07:57', 2: 'Salário', 3: 'Portabilidade', 6: 'Pagamento recebido', 10: '2,733.74' }, 11), // row 13
+      ];
+      expect(() => parsearLinhasCSVXLSX(rows)).not.toThrow();
+      const resultado = parsearLinhasCSVXLSX(rows);
+      const validas = resultado.filter(r => !r.erro);
+      expect(validas).toHaveLength(2);
+      expect(validas[0].descricao).toBe('Art Lanches');
+      expect(validas[1].descricao).toBe('Pagamento recebido');
+      expect(validas[1].valor).toBeCloseTo(2733.74, 2);
+    });
   });
 });


### PR DESCRIPTION
Dois bugs simultâneos descobertos no QA do BUG-028: (1) SheetJS retorna arrays sparse com holes undefined → findIndex visitava undefined → crash 'Cannot read properties of undefined (reading includes)'; (2) BTG tem coluna Categoria → _detectarTipo retornava receita em vez de banco. Fix: Array.from() em todos os map/findIndex + regra receita exclui 'Data e hora'. 5 novos TCs. v3.23.8.