### PR TITLE
fix(importar): responsavel salvo como valor negativo em extrato bancario (#156)

### DIFF
--- a/src/js/utils/normalizadorTransacoes.js
+++ b/src/js/utils/normalizadorTransacoes.js
@@ -73,9 +73,12 @@ export function parsearLinhasCSVXLSX(rows, {
     idxConta    = h.findIndex(c => c.includes('conta') || c.includes('banco'));
     idxCredito  = h.findIndex(c => c.includes('credito'));
     idxDebito   = h.findIndex(c => c.includes('debito'));
-    if (idxData < 0)     idxData = 0;
-    if (idxEstab < 0)    idxEstab = 1;
-    if (idxPortador < 0) idxPortador = 2;
+    if (idxData < 0)  idxData = 0;
+    if (idxEstab < 0) idxEstab = 1;
+    // BUG-030: NÃO aplicar fallback para idxPortador quando o header foi detectado.
+    // Extratos bancários não têm coluna portador/titular; o fallback idxPortador=2
+    // apontava para a coluna Valor, salvando o valor bruto ("-42.5") como responsavel.
+    // Manter idxPortador=-1 → portador='' na leitura abaixo.
     if (idxValor < 0 && idxCredito < 0) idxValor = 3;
   }
   const dataRows = headerIdx >= 0 ? rows.slice(headerIdx + 1) : rows.slice(1);
@@ -91,7 +94,8 @@ export function parsearLinhasCSVXLSX(rows, {
     // BUG-028: BTG XLS inclui horário em "Data e hora", e.g. "30/03/2026 18:43" → extrair só a data
     const dataRaw  = String(row[idxData]     ?? '').trim().split(' ')[0];
     const estab    = String(row[idxEstab]    ?? '').trim();
-    const portador = String(row[idxPortador] ?? '').trim();
+    // BUG-030: idxPortador=-1 quando o header não tem coluna portador/titular (extrato bancário)
+    const portador = idxPortador >= 0 ? String(row[idxPortador] ?? '').trim() : '';
     const valorRaw = String(row[idxValor]    ?? '').trim();
     // NRF-002.1: normaliza "X de Y" → "XX/YY" para compatibilidade com projeções
     const parcela  = idxParcela >= 0 ? normalizarParcela(String(row[idxParcela] ?? '').trim()) : '-';

--- a/tests/utils/normalizadorTransacoes.test.js
+++ b/tests/utils/normalizadorTransacoes.test.js
@@ -522,6 +522,75 @@ describe('parsearLinhasCSVXLSX', () => {
       expect(resultado[0].descricao).toBe('Art Lanches');
     });
 
+    // BUG-030: portador salvo como valor negativo em extrato bancário
+    describe('BUG-030 — responsavel vazio em extrato bancário sem coluna portador', () => {
+      it('header sem coluna portador/titular → portador=""', () => {
+        const rows = [
+          ['Data', 'Historico', 'Valor'],
+          ['25/03/2026', 'Supermercado Pao de Acucar', '-150,00'],
+        ];
+        const resultado = parsearLinhasCSVXLSX(rows);
+        expect(resultado).toHaveLength(1);
+        expect(resultado[0].portador).toBe('');
+        expect(resultado[0].valor).toBe(150);
+        expect(resultado[0].erro).toBeNull();
+      });
+
+      it('portador NÃO deve ser string de valor numérico negativo ("-150.00")', () => {
+        const rows = [
+          ['Data', 'Historico', 'Valor'],
+          ['25/03/2026', 'Farmacia Drogasil', '-42.50'],
+          ['26/03/2026', 'Mercado Municipal', '-250.00'],
+          ['27/03/2026', 'Netflix', '-55.90'],
+        ];
+        const resultado = parsearLinhasCSVXLSX(rows);
+        expect(resultado).toHaveLength(3);
+        resultado.forEach(l => {
+          expect(l.portador).toBe('');
+          expect(l.portador).not.toMatch(/^-?\d/); // nunca valor numérico
+        });
+      });
+
+      it('header com coluna portador → portador preservado corretamente (regressão)', () => {
+        const rows = [
+          ['Data', 'Estabelecimento', 'Portador', 'Valor', 'Parcela'],
+          ['25/03/2026', 'Shopee', 'Luigi', '150,00', '-'],
+        ];
+        const resultado = parsearLinhasCSVXLSX(rows);
+        expect(resultado[0].portador).toBe('Luigi');
+      });
+
+      it('extrato bancário com colunas Credito/Debito (sem portador) → portador=""', () => {
+        const rows = [
+          ['Data', 'Historico', 'Credito', 'Debito'],
+          ['25/03/2026', 'Salario Empresa X', '5000,00', ''],
+          ['26/03/2026', 'Conta de Luz', '', '180,00'],
+        ];
+        const resultado = parsearLinhasCSVXLSX(rows);
+        expect(resultado).toHaveLength(2);
+        resultado.forEach(l => {
+          expect(l.portador).toBe('');
+        });
+        expect(resultado[0].isNegativo).toBe(false); // crédito positivo → não negativo
+        expect(resultado[1].isNegativo).toBe(true);  // débito → valorBruto negativo
+      });
+
+      it('chave_dedup com portador="" é gerada sem valor numérico embutido', () => {
+        const rows = [
+          ['Data', 'Historico', 'Valor'],
+          ['25/03/2026', 'Supermercado Extra', '-99,90'],
+        ];
+        const resultado = parsearLinhasCSVXLSX(rows);
+        const chave = resultado[0].chave_dedup;
+        // Chave não deve conter segmentos numéricos do portador (ex: "99.90||")
+        // A chave sem portador contém data||desc||valor||''
+        expect(chave).not.toBeNull();
+        const partes = chave.split('||');
+        // Portador normalizado = '' → último segmento é string vazia
+        expect(partes[partes.length - 1]).toBe('');
+      });
+    });
+
     it('BUG-028b: arrays sparse com header na linha 10 (estrutura completa BTG real)', () => {
       // Reproduz exatamente a estrutura do arquivo real: rows[i] são sparse (SheetJS)
       const mkSparse = (obj, len) => Object.assign(new Array(len), obj);


### PR DESCRIPTION
## O que foi feito

- **Root cause:** Em `parsearLinhasCSVXLSX`, quando o CSV de extrato bancário tem header detectado mas sem coluna `portador`/`titular`, o `findIndex` retorna -1 e o fallback `if (idxPortador < 0) idxPortador = 2` forcava apontar para a coluna Valor. Resultado: `portador = "-42.5"` salvo como `responsavel` no Firestore.
- **Fix:** Removido o fallback `idxPortador = 2` dentro do bloco `headerIdx >= 0`. Quando o header existe mas nao tem coluna portador, `idxPortador = -1` → `portador = ''`.
- **Bonus:** A condicao `!l.portador` em `importar.js:_aplicarTipo('banco')` agora funciona corretamente — antes, a string numerica era truthy e impedia a auto-atribuicao do responsavel ao usuario logado.
- **Testes:** +5 regressoes BUG-030 adicionadas em `normalizadorTransacoes.test.js`

## Arquivos alterados

- `src/js/utils/normalizadorTransacoes.js` — 2 linhas alteradas (fallback removido + guard na leitura)
- `tests/utils/normalizadorTransacoes.test.js` — 5 testes de regressao adicionados

## Subagentes

- test-runner: **PASS** — 519/519 testes, zero falhas, normalizadorTransacoes.js 95% cobertura
- import-pipeline-reviewer: **PASS** — chave_dedup correta, mesFatura nao afetado, pipeline 15 bancos sem regressao

## Como testar

- [ ] `npm test` (519 passando)
- [ ] `npm run build`
- [ ] Importar CSV extrato bancario com valores negativos → modal de edicao funciona, responsavel vazio

## Checklist

- [x] `npm test` 519 passando
- [x] Sem credenciais Firebase no diff
- [x] CSS nao alterado
- [x] `chave_dedup` intacta — portador vazio preserva formato `data||desc||valor||`
- [x] `mesFatura` nao afetado — nao existe em extrato bancario
- [x] `grupoId` nao afetado — nao alterado neste fix
- [x] `escHTML()` nao afetado — nao ha innerHTML neste modulo
- [x] `onSnapshot` nao afetado — nao ha listeners neste modulo

Closes #156