### PR TITLE
fix(importar): categoriaId salvo como string sentinela em pagamento_fatura (#157)

### DIFF
--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -1015,6 +1015,7 @@ async function executarImportacao() {
         despDados.membroDestinoId = l._transferenciaInterna.membroUid;
         despDados.isConjunta = false; // transferências internas nunca são conjuntas
         despDados.valorAlocado = null;
+        despDados.categoriaId = null; // BUG-031: __tipo__transferencia_interna não é uma categoriaId válida
       }
       // RF-064: marca despesa como pagamento de fatura se detectado
       if (l._pagamentoFatura && !l._transferenciaInterna) {
@@ -1024,6 +1025,7 @@ async function executarImportacao() {
         if (l._pagamentoFatura.contaCartaoId) despDados.contaCartaoId = l._pagamentoFatura.contaCartaoId;
         despDados.isConjunta = false; // pagamento de fatura nunca é conjunta
         despDados.valorAlocado = null;
+        despDados.categoriaId = null; // BUG-031: __tipo__pagamento_fatura não é uma categoriaId válida
       }
       const despesaRef = await criarDespesaDB(modelDespesa(despDados));
       // NRF-002: reconciliação por matching exato

--- a/tests/models/Despesa.test.js
+++ b/tests/models/Despesa.test.js
@@ -1,0 +1,132 @@
+// ============================================================
+// Testes — models/Despesa.js
+// Valida o modelo de despesa e o comportamento de campos
+// especiais (isConjunta, mesFatura, categoriaId etc.).
+//
+// BUG-031: garante que categoriaId nunca contém strings de
+// sentinela '__tipo__*' no objeto que vai para o Firestore.
+// ============================================================
+import { describe, it, expect } from 'vitest';
+import { modelDespesa } from '../../src/js/models/Despesa.js';
+
+// ── Fixture base ─────────────────────────────────────────────────────────────
+
+function base(overrides = {}) {
+  return {
+    grupoId:     'grupo-1',
+    usuarioId:   'user-1',
+    categoriaId: 'cat-alimentacao',
+    descricao:   'Supermercado',
+    valor:       150,
+    data:        new Date('2026-04-15T12:00:00'),
+    ...overrides,
+  };
+}
+
+// ── modelDespesa — campos obrigatórios ────────────────────────────────────────
+
+describe('modelDespesa — campos obrigatórios e defaults', () => {
+  it('inclui grupoId, usuarioId, categoriaId, descricao, valor e data', () => {
+    const d = modelDespesa(base());
+    expect(d.grupoId).toBe('grupo-1');
+    expect(d.usuarioId).toBe('user-1');
+    expect(d.categoriaId).toBe('cat-alimentacao');
+    expect(d.descricao).toBe('Supermercado');
+    expect(d.valor).toBe(150);
+    expect(d.data).toBeInstanceOf(Date);
+  });
+
+  it('isConjunta e valorAlocado são false/null por padrão', () => {
+    const d = modelDespesa(base());
+    expect(d.isConjunta).toBe(false);
+    expect(d.valorAlocado).toBeNull();
+  });
+
+  it('isConjunta=true calcula valorAlocado como 50%', () => {
+    const d = modelDespesa(base({ isConjunta: true, valor: 200 }));
+    expect(d.isConjunta).toBe(true);
+    expect(d.valorAlocado).toBe(100);
+  });
+
+  it('campos opcionais ausentes não aparecem no objeto', () => {
+    const d = modelDespesa(base());
+    expect(d).not.toHaveProperty('portador');
+    expect(d).not.toHaveProperty('parcela');
+    expect(d).not.toHaveProperty('mesFatura');
+  });
+
+  it('campos opcionais presentes são incluídos', () => {
+    const d = modelDespesa(base({ portador: 'Luigi', origemBanco: 'nubank', status: 'pago' }));
+    expect(d.portador).toBe('Luigi');
+    expect(d.origemBanco).toBe('nubank');
+    expect(d.status).toBe('pago');
+  });
+
+  it('data como string é convertida para Date', () => {
+    const d = modelDespesa(base({ data: '2026-04-15' }));
+    expect(d.data).toBeInstanceOf(Date);
+  });
+
+  it('descrição é trimada', () => {
+    const d = modelDespesa(base({ descricao: '  Supermercado  ' }));
+    expect(d.descricao).toBe('Supermercado');
+  });
+});
+
+// ── BUG-031: categoriaId não deve ser string de sentinela ─────────────────────
+
+describe('modelDespesa — BUG-031: categoriaId de tipos especiais', () => {
+  it('REGRESSÃO BUG-031: categoriaId=null é convertido para "" (não para string de sentinela)', () => {
+    // importar.js agora seta despDados.categoriaId = null nos blocos RF-063/064.
+    // modelDespesa converte null → '' via operador ??
+    // Resultado: Firestore recebe '' em vez de '__tipo__pagamento_fatura'
+    const d = modelDespesa(base({ categoriaId: null }));
+    expect(d.categoriaId).toBe('');
+    expect(d.categoriaId).not.toBe('__tipo__pagamento_fatura');
+    expect(d.categoriaId).not.toBe('__tipo__transferencia_interna');
+  });
+
+  it('simulação pre-fix: categoriaId com string sentinela passada diretamente ao model', () => {
+    // Documenta o comportamento BUG-031: antes do fix, despDados.categoriaId = '__tipo__...'
+    // era passado para modelDespesa diretamente → string de sentinela salva no Firestore
+    const d = modelDespesa(base({ categoriaId: '__tipo__pagamento_fatura' }));
+    // O model preserva a string como recebe — o problema era no importar.js
+    expect(d.categoriaId).toBe('__tipo__pagamento_fatura'); // documenta o bug (comportamento do model)
+  });
+
+  it('simulação pos-fix RF-064: despDados.categoriaId=null antes de passar ao model', () => {
+    // Reproduz a cadeia exata do fix:
+    //   despDados.categoriaId = cat; // → '__tipo__pagamento_fatura' (do select DOM)
+    //   despDados.tipo = 'pagamento_fatura';
+    //   despDados.categoriaId = null; // ← linha adicionada pelo BUG-031 fix
+    //   modelDespesa(despDados)       // → categoriaId: ''
+    const despDados = base({ categoriaId: '__tipo__pagamento_fatura', tipo: 'pagamento_fatura' });
+    despDados.categoriaId = null; // BUG-031 fix
+    const d = modelDespesa(despDados);
+    expect(d.categoriaId).toBe('');
+    expect(d.categoriaId).not.toMatch(/^__tipo__/);
+  });
+
+  it('simulação pos-fix RF-063: transferencia_interna tem categoriaId="" apos fix', () => {
+    const despDados = base({ categoriaId: '__tipo__transferencia_interna', tipo: 'transferencia_interna' });
+    despDados.categoriaId = null; // BUG-031 fix
+    const d = modelDespesa(despDados);
+    expect(d.categoriaId).toBe('');
+    expect(d.categoriaId).not.toMatch(/^__tipo__/);
+  });
+
+  it('tipo pagamento_fatura com mesFatura e contaCartaoId (campos RF-064)', () => {
+    const d = modelDespesa(base({
+      categoriaId:  null,
+      tipo:         'pagamento_fatura',
+      contaCartaoId: 'conta-nubank',
+      scoreFatura:  85,
+      statusReconciliacaoFatura: 'auto',
+    }));
+    expect(d.tipo).toBe('pagamento_fatura');
+    expect(d.contaCartaoId).toBe('conta-nubank');
+    expect(d.scoreFatura).toBe(85);
+    expect(d.categoriaId).toBe(''); // null → '' via ??
+    expect(d.categoriaId).not.toMatch(/^__tipo__/);
+  });
+});


### PR DESCRIPTION
## O que foi feito

- **Root cause:** `executarImportacao()` em `importar.js` lê o valor do select DOM como `cat` (`'__tipo__pagamento_fatura'` ou `'__tipo__transferencia_interna'`). Os blocos RF-063 e RF-064, ao sobrescrever `tipo`, não resetavam `despDados.categoriaId`. Resultado: string sentinela salva no Firestore → exibida na coluna Categoria de `base-dados.html`.
- **Fix:** 2 linhas adicionadas (uma em cada bloco):
  - RF-063: `despDados.categoriaId = null; // BUG-031`
  - RF-064: `despDados.categoriaId = null; // BUG-031`
  `modelDespesa` converte `null → ''` via `??`, resultando em `categoriaId: ''` (campo vazio) no Firestore.
- **Testes:** +12 TCs em `tests/models/Despesa.test.js` (novo arquivo) — inclui simulação da cadeia pre-fix vs. pos-fix para RF-063 e RF-064.

## Achado colateral (fora de escopo — próxima sessão)

`mesFatura` não está na lista `opcionais` de `modelDespesa`, o que significa que o campo pode ser descartado no model antes de ser salvo no Firestore. Registrado para investigação em sessão separada.

## Arquivos alterados

- `src/js/pages/importar.js` — 2 linhas adicionadas nos blocos RF-063 e RF-064
- `tests/models/Despesa.test.js` — novo arquivo, 12 TCs

## Subagentes

- test-runner: **em andamento**
- import-pipeline-reviewer: **em andamento**

## Como testar

- [ ] `npm test` (537+ passando)
- [ ] `npm run build`
- [ ] Importar extrato bancário com pagamento de fatura: `categoriaId = ''` no Firestore (não `'__tipo__pagamento_fatura'`); `base-dados.html` exibe `—` na coluna Categoria

## Checklist

- [x] `npm test` local 12/12 novos TCs passando
- [x] Sem credenciais Firebase no diff
- [x] `chave_dedup` não afetada — mudança não toca o campo
- [x] `mesFatura` não afetado — mudança não toca o campo
- [x] `grupoId` presente em todas as queries — mudança não toca Firestore queries
- [x] `escHTML()` não afetado — sem innerHTML novo com dados do usuário

Closes #157