### PR TITLE
fix(models): adicionar mesFatura aos opcionais de Despesa e Receita (BUG-032 / #162)

### DIFF
--- a/src/js/models/Despesa.js
+++ b/src/js/models/Despesa.js
@@ -28,6 +28,7 @@ export function modelDespesa(dados) {
     'tipo', 'chave_dedup', 'parcelamento_id', 'importadoEm', 'status',
     'contaId',      // NRF-004: conta/banco de origem
     'dataOriginal', // NRF-002.1: data original da compra (parceladas com data ajustada)
+    'mesFatura',    // BUG-032: ciclo de faturamento "YYYY-MM" — obrigatório para a aba Fatura
     'origemBanco',  // RF-021: banco/emissor detectado ('itau', 'nubank', ...)
     'contrapartidaId',         // RF-063: id da despesa/receita contraparte
     'membroDestinoId',         // RF-063: uid do membro destinatário

--- a/src/js/models/Receita.js
+++ b/src/js/models/Receita.js
@@ -23,6 +23,7 @@ export function modelReceita(dados) {
     'origem',       // NRF-006: 'importacao' | 'manual'
     'chave_dedup',  // NRF-006: deduplicação
     'importadoEm',  // NRF-006: timestamp de importação
+    'mesFatura',    // BUG-032: ciclo de faturamento "YYYY-MM" — necessário para estornos de cartão
     'origemBanco',  // RF-021: banco/emissor detectado ('itau', 'nubank', ...)
     'tipo',                    // RF-063: 'transferencia_interna' (receita-lado do par)
     'contrapartidaId',         // RF-063: id da despesa/receita contraparte

--- a/tests/models/Despesa.test.js
+++ b/tests/models/Despesa.test.js
@@ -52,7 +52,6 @@ describe('modelDespesa — campos obrigatórios e defaults', () => {
     const d = modelDespesa(base());
     expect(d).not.toHaveProperty('portador');
     expect(d).not.toHaveProperty('parcela');
-    expect(d).not.toHaveProperty('mesFatura');
   });
 
   it('campos opcionais presentes são incluídos', () => {
@@ -60,6 +59,18 @@ describe('modelDespesa — campos obrigatórios e defaults', () => {
     expect(d.portador).toBe('Luigi');
     expect(d.origemBanco).toBe('nubank');
     expect(d.status).toBe('pago');
+  });
+
+  it('REGRESSÃO BUG-032: mesFatura é propagado ao Firestore quando fornecido', () => {
+    // Antes do fix, mesFatura estava ausente da lista opcionais — o campo era
+    // descartado silenciosamente, tornando a aba Fatura sempre vazia para novas importações.
+    const d = modelDespesa(base({ mesFatura: '2026-04' }));
+    expect(d.mesFatura).toBe('2026-04');
+  });
+
+  it('REGRESSÃO BUG-032: mesFatura ausente no input não aparece no objeto (comportamento correto)', () => {
+    const d = modelDespesa(base());
+    expect(d).not.toHaveProperty('mesFatura');
   });
 
   it('data como string é convertida para Date', () => {

--- a/tests/models/Receita.test.js
+++ b/tests/models/Receita.test.js
@@ -1,0 +1,60 @@
+// ============================================================
+// Testes — models/Receita.js
+//
+// BUG-032: garante que mesFatura é propagado ao Firestore
+// quando presente no objeto de entrada (estava ausente da
+// lista opcionais, tornando a aba Fatura vazia para estornos
+// de cartão importados).
+// ============================================================
+import { describe, it, expect } from 'vitest';
+import { modelReceita } from '../../src/js/models/Receita.js';
+
+function base(overrides = {}) {
+  return {
+    grupoId:     'grupo-1',
+    usuarioId:   'user-1',
+    categoriaId: 'cat-outros',
+    descricao:   'Crédito Estorno',
+    valor:       50,
+    data:        new Date('2026-04-15T12:00:00'),
+    ...overrides,
+  };
+}
+
+describe('modelReceita — campos obrigatórios e defaults', () => {
+  it('inclui grupoId, usuarioId, categoriaId, descricao, valor e data', () => {
+    const r = modelReceita(base());
+    expect(r.grupoId).toBe('grupo-1');
+    expect(r.usuarioId).toBe('user-1');
+    expect(r.categoriaId).toBe('cat-outros');
+    expect(r.descricao).toBe('Crédito Estorno');
+    expect(r.valor).toBe(50);
+    expect(r.data).toBeInstanceOf(Date);
+  });
+
+  it('campos opcionais ausentes não aparecem no objeto', () => {
+    const r = modelReceita(base());
+    expect(r).not.toHaveProperty('responsavel');
+    expect(r).not.toHaveProperty('origemBanco');
+  });
+
+  it('data como string é convertida para Date', () => {
+    const r = modelReceita(base({ data: '2026-04-15' }));
+    expect(r.data).toBeInstanceOf(Date);
+  });
+});
+
+describe('modelReceita — BUG-032: mesFatura deve ser propagado', () => {
+  it('REGRESSÃO BUG-032: mesFatura é incluído no objeto quando fornecido', () => {
+    // Antes do fix, mesFatura estava ausente da lista opcionais — estornos
+    // de cartão importados não apareciam corretamente na aba Fatura.
+    const r = modelReceita(base({ mesFatura: '2026-04', origem: 'importacao' }));
+    expect(r.mesFatura).toBe('2026-04');
+    expect(r.origem).toBe('importacao');
+  });
+
+  it('REGRESSÃO BUG-032: mesFatura ausente no input não aparece no objeto (comportamento correto)', () => {
+    const r = modelReceita(base());
+    expect(r).not.toHaveProperty('mesFatura');
+  });
+});


### PR DESCRIPTION
## Problema

`mesFatura` estava ausente das listas `opcionais` de `modelDespesa` e `modelReceita`. O campo era descartado silenciosamente ao passar por esses models antes do `criarDespesaDB` / `criarReceita`.

**Impacto:** toda importação nova (modo cartão ou banco) não persistia `mesFatura` no Firestore → `ouvirDespesasPorMesFatura()` em `database.js` fazia `where('mesFatura', '==', ...)` e retornava zero resultados → **aba Fatura ficava sempre vazia para novos imports**.

O único path que funcionava era o de duplicatas (linhas 1089–1091 em `importar.js`), que chama `atualizarDespesa`/`atualizarReceita` diretamente — bypassando os models.

## Fix

Adicionar `'mesFatura'` à lista `opcionais` em:
- `src/js/models/Despesa.js`
- `src/js/models/Receita.js`

2 linhas de mudança de produção.

## Testes

- `tests/models/Despesa.test.js`: +2 testes de regressão BUG-032
- `tests/models/Receita.test.js`: novo arquivo com 5 testes (3 gerais + 2 regressão BUG-032)
- **544 testes passando** (+7 vs. v3.24.0)

## Checklist

- [x] `npm test` — 544/544 ✅
- [x] Fix cobre Despesa e Receita
- [x] Testes de regressão para o comportamento correto E o ausente

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)