### PR TITLE
feat(importar): duplicata no preview faz update, não insert (ENH-001 / #149)

### DIFF
--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -965,6 +965,26 @@ async function executarImportacao() {
     const valorAlocado    = isConj ? Math.round(valorBase  * 100 / 2) / 100 : null; // para a despesa atual
     const valorAlocadoProj = isConj ? Math.round(l.valor   * 100 / 2) / 100 : null; // para projeções (valor bruto)
     try {
+      // ENH-001 (#149): linha marcada como duplicata com docId existente — atualizar o
+      // documento já salvo em vez de criar um novo (evita duplicação de registros no Firestore).
+      // O usuário pode marcar manualmente uma duplicata para corrigir categoria/conta/portador.
+      if (l.duplicado && l.duplicado_docId) {
+        const camposAtualizar = {
+          categoriaId: cat,
+          responsavel: l.portador ?? '',
+          portador:    l.portador ?? '',
+          isConjunta:  isConj,
+          valorAlocado,
+          ...(contaId ? { contaId } : {}),
+        };
+        if (l.tipoLinha === 'receita') {
+          await atualizarReceita(l.duplicado_docId, camposAtualizar);
+        } else {
+          await atualizarDespesa(l.duplicado_docId, camposAtualizar);
+        }
+        sucesso++;
+        continue;
+      }
       // NRF-006: modo banco — linhas de receita vão para coleção 'receitas'
       if (l.tipoLinha === 'receita') {
         const recDados = {

--- a/tests/utils/deduplicador.test.js
+++ b/tests/utils/deduplicador.test.js
@@ -82,6 +82,55 @@ describe('marcarLinhasDuplicatas — matching exato', () => {
   });
 });
 
+// ── duplicado_docId — pré-requisito de ENH-001 ───────────────────────────────
+//
+// ENH-001: quando o usuário marca manualmente uma linha duplicada no preview,
+// executarImportacao() usa l.duplicado_docId para chamar atualizarDespesa() em
+// vez de criarDespesaDB(). Estes testes garantem que o deduplicador popula
+// duplicado_docId corretamente a partir de um Map<chave_dedup, docId>.
+
+describe('marcarLinhasDuplicatas — duplicado_docId (ENH-001)', () => {
+  it('popula duplicado_docId quando chavesDesp é um Map', () => {
+    const linha = criarLinha({ chave_dedup: 'chave-001' });
+    const chavesDesp = new Map([['chave-001', 'doc-id-firestore-123']]);
+
+    marcarLinhasDuplicatas([linha], { chavesDesp });
+
+    expect(linha.duplicado).toBe(true);
+    expect(linha.duplicado_docId).toBe('doc-id-firestore-123');
+  });
+
+  it('duplicado_docId é null quando chavesDesp é um Set (legado, sem docId)', () => {
+    const linha = criarLinha({ chave_dedup: 'chave-001' });
+    const chavesDesp = new Set(['chave-001']);
+
+    marcarLinhasDuplicatas([linha], { chavesDesp });
+
+    expect(linha.duplicado).toBe(true);
+    expect(linha.duplicado_docId).toBeNull();
+  });
+
+  it('receita: duplicado_docId é populado a partir de chavesRec Map', () => {
+    const linha = criarLinha({ tipoLinha: 'receita', chave_dedup: 'chave-rec-001' });
+    const chavesRec = new Map([['chave-rec-001', 'rec-doc-id-456']]);
+
+    marcarLinhasDuplicatas([linha], { chavesRec });
+
+    expect(linha.duplicado).toBe(true);
+    expect(linha.duplicado_docId).toBe('rec-doc-id-456');
+  });
+
+  it('linha sem match não recebe duplicado_docId', () => {
+    const linha = criarLinha({ chave_dedup: 'chave-nova' });
+    const chavesDesp = new Map([['chave-existente', 'doc-id-123']]);
+
+    marcarLinhasDuplicatas([linha], { chavesDesp });
+
+    expect(linha.duplicado).toBe(false);
+    expect(linha).not.toHaveProperty('duplicado_docId');
+  });
+});
+
 // ── tipoExtrato 'banco' → delega para detectarAjustesParciais e retorna ───────
 
 describe('marcarLinhasDuplicatas — tipoExtrato banco', () => {


### PR DESCRIPTION
## Problema

Quando um arquivo de extrato era importado e algumas linhas eram detectadas como duplicatas (já existiam no Firestore via `chave_dedup`), o usuário podia marcar manualmente uma linha duplicada para corrigir sua categoria ou conta. Porém, ao clicar em **Importar**, o sistema criava um **novo documento** (`criarDespesaDB`) em vez de atualizar o existente — resultando em duas cópias do mesmo lançamento no Firestore.

## Fix

Em `executarImportacao()` ([`src/js/pages/importar.js`](src/js/pages/importar.js)), adicionado check no início do loop de importação:

```js
// ENH-001: linha duplicada com docId → atualizar em vez de inserir
if (l.duplicado && l.duplicado_docId) {
  const camposAtualizar = { categoriaId, contaId, responsavel, portador, isConjunta, valorAlocado };
  await atualizarDespesa / atualizarReceita(l.duplicado_docId, camposAtualizar);
  sucesso++; continue;
}
```

Campos atualizados: `categoriaId`, `contaId`, `responsavel`, `portador`, `isConjunta`, `valorAlocado`.

Campos **preservados** (não sobrescritos): `tipo`, `mesFatura`, `data`, `valor`, `chave_dedup`, `descricao`.

## Impacto

- Linha duplicada **não** checada → nenhuma alteração (comportamento anterior preservado)
- Linha duplicada **checada** → `updateDoc` no documento existente (ENH-001)
- mesFatura de duplicatas cartão → ainda propagado pelo loop separado (linhas 1082–1096), que cobre todas as duplicatas

## Testes

- `tests/utils/deduplicador.test.js`: +4 testes cobrindo `duplicado_docId` populado a partir de `Map` (pré-requisito do branch de update do ENH-001)
- **548 testes passando**

## Checklist

- [x] `npm test` — 548/548 ✅
- [x] import-pipeline-reviewer: mudança isolada, sem afetar path normal de insert
- [x] Compatível com mesFatura loop (não duplica updates para duplicatas de cartão)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)