### PR TITLE
feat(dashboard): RF-065 — card Próxima Fatura na home + tab Projeções como default (#153)

### DIFF
--- a/src/css/dashboard.css
+++ b/src/css/dashboard.css
@@ -93,6 +93,16 @@
 .resumo-card--disponivel::before { background: var(--color-primary); opacity: 0.5; }
 .resumo-card--meu-bolso::before { background: var(--color-budget); opacity: 1; }
 .resumo-card--familia::before   { background: var(--color-ok); opacity: 1; }
+.resumo-card--fatura::before    { background: var(--color-warning); opacity: 1; }
+
+.proxima-fatura-link {
+  font-size: var(--font-size-xs);
+  color: var(--color-primary);
+  text-decoration: none;
+  margin-top: var(--space-2);
+  font-weight: 600;
+}
+.proxima-fatura-link:hover { text-decoration: underline; }
 
 .resumo-label {
   font-size: var(--font-size-xs);

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -91,6 +91,13 @@
           <span class="resumo-valor" id="total-familia">R$ 0,00</span>
           <span class="resumo-sublabel">total conjunto do grupo</span>
         </div>
+        <!-- RF-065: card Próxima Fatura (visível apenas quando há projeções para o próximo mês) -->
+        <div class="card resumo-card resumo-card--fatura" id="card-proxima-fatura" style="display:none;">
+          <span class="resumo-label">💳 Próxima Fatura</span>
+          <span class="resumo-valor" id="proxima-fatura-total">R$ 0,00</span>
+          <div id="proxima-fatura-membros" class="resumo-sublabel"></div>
+          <a href="fatura.html?tab=projecoes" class="proxima-fatura-link">ver projeções →</a>
+        </div>
       </div>
 
       <!-- ── Categorias de Despesas ── -->

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -10,6 +10,7 @@ import {
   ouvirParcelamentosAbertos,
   ouvirReceitas,
   ouvirCategoriasReceita,
+  ouvirDespesasPorMesFatura,  // RF-065: card Próxima Fatura
   garantirCategoriasReceita,
   garantirContasPadrao,       // NRF-004
   migrarCartaoGenerico,       // RF-062
@@ -29,7 +30,7 @@ import { CATEGORIAS_RECEITA_PADRAO } from './models/Receita.js';
 import { CONTAS_PADRAO } from './models/Conta.js';            // NRF-004
 import { mesAnoAtual, definirTexto, isMovimentacaoReal } from './utils/helpers.js';
 import { coresGrafico } from './utils/chartColors.js';
-import { nomeMes } from './utils/formatters.js';
+import { nomeMes, escHTML } from './utils/formatters.js';
 import { skeletonCards, errorStateHTML } from './utils/skeletons.js';
 import { inicializarCapacitor } from './utils/capacitor.js';
 
@@ -37,7 +38,8 @@ import { inicializarCapacitor } from './utils/capacitor.js';
 let estadoApp = {
   usuario:    null,
   perfil:     null,
-  nomeAtual:  '',   // nome do usuário logado conforme nomesMembros do grupo (fix #90)
+  grupo:      null,         // RF-065: card Próxima Fatura — membros do grupo
+  nomeAtual:  '',           // nome do usuário logado conforme nomesMembros do grupo (fix #90)
   mes:        mesAnoAtual().mes,
   ano:        mesAnoAtual().ano,
   categorias:         [],
@@ -48,12 +50,13 @@ let estadoApp = {
 };
 
 // Referências para unsubscribe ao trocar período
-let _unsubCats    = null;
-let _unsubDesp    = null;
-let _unsubOrc     = null;
-let _unsubProj    = null; // RF-014: parcelamentos em aberto
-let _unsubRec     = null; // receitas do mês
-let _unsubCatRec  = null; // categorias de receita
+let _unsubCats        = null;
+let _unsubDesp        = null;
+let _unsubOrc         = null;
+let _unsubProj        = null; // RF-014: parcelamentos em aberto
+let _unsubRec         = null; // receitas do mês
+let _unsubCatRec      = null; // categorias de receita
+let _unsubProxFatura  = null; // RF-065: card Próxima Fatura
 
 // ── RF-017: Gráficos ──────────────────────────────────────────
 const MESES_ABREV = ['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','Nov','Dez'];
@@ -93,6 +96,7 @@ onAuthChange(async (user) => {
     // Resolve nome do usuário logado para cálculo correto de "Meu Bolso" (fix #90)
     const grupo = await buscarGrupo(estadoApp.perfil?.grupoId);
     estadoApp.nomeAtual = grupo?.nomesMembros?.[user.uid] ?? user.email ?? '';
+    estadoApp.grupo = grupo; // RF-065: armazenar membros para card Próxima Fatura
   } catch (_err) {
     // Falha ao buscar perfil (ex: erro de rede) → redireciona para login por segurança
     window.location.href = 'login.html';
@@ -108,8 +112,9 @@ onAuthChange(async (user) => {
   atualizarTituloPeriodo();
   preencherSelectPeriodo();
   iniciarListeners();
-  iniciarListenerParcelamentos(estadoApp.perfil.grupoId); // RF-014
+  iniciarListenerParcelamentos(estadoApp.perfil.grupoId);   // RF-014
   iniciarListenerCategoriasReceita(estadoApp.perfil.grupoId);
+  iniciarListenerProximaFatura(estadoApp.perfil.grupoId);   // RF-065
   garantirCategoriasReceita(estadoApp.perfil.grupoId, CATEGORIAS_RECEITA_PADRAO).catch(() => {});
   garantirContasPadrao(estadoApp.perfil.grupoId, CONTAS_PADRAO).catch(() => {}); // NRF-004
   migrarCartaoGenerico(estadoApp.perfil.grupoId).catch(() => {}); // RF-062: marca cartão genérico como _legado
@@ -608,4 +613,61 @@ function preencherSelectPeriodo() {
 function atualizarTituloPeriodo() {
   const el = document.getElementById('mes-ano-atual');
   if (el) el.textContent = `${nomeMes(estadoApp.mes)} ${estadoApp.ano}`;
+}
+
+// ── RF-065: Card Próxima Fatura ───────────────────────────────
+
+function iniciarListenerProximaFatura(grupoId) {
+  if (_unsubProxFatura) _unsubProxFatura();
+  const agora = new Date();
+  let nextMes = agora.getMonth() + 2; // +1 zero-index, +1 próximo mês
+  let nextAno = agora.getFullYear();
+  if (nextMes > 12) { nextMes = 1; nextAno++; }
+  const proximoMesFatura = `${nextAno}-${String(nextMes).padStart(2, '0')}`;
+
+  _unsubProxFatura = ouvirDespesasPorMesFatura(grupoId, proximoMesFatura, (despesas) => {
+    const projecoes = despesas.filter(d => d.tipo === 'projecao');
+    renderizarCardProximaFatura(projecoes);
+  });
+}
+
+function renderizarCardProximaFatura(projecoes) {
+  const card = document.getElementById('card-proxima-fatura');
+  if (!card) return;
+  if (!projecoes.length) {
+    card.style.display = 'none';
+    return;
+  }
+  card.style.display = '';
+
+  // Total geral da fatura (soma de todos os valores)
+  const total = projecoes.reduce((s, d) => s + (d.valor ?? 0), 0);
+
+  // Totais por membro (individual + 50% conjuntas via valorAlocado)
+  const membros = estadoApp.grupo?.nomesMembros
+    ? Object.entries(estadoApp.grupo.nomesMembros).map(([, nome]) => ({
+        nome,
+        key: nome.split(' ')[0].toLowerCase(),
+      }))
+    : [];
+
+  const conjuntas = projecoes.filter(d => d.isConjunta);
+  const porMembro = {};
+  membros.forEach(m => {
+    const ind   = projecoes.filter(d =>
+      !d.isConjunta && (d.responsavel || d.portador || '').toLowerCase().startsWith(m.key)
+    );
+    const tInd  = ind.reduce((s, d) => s + (d.valor ?? 0), 0);
+    const tConj = conjuntas.reduce((s, d) => s + (d.valorAlocado ?? (d.valor ?? 0) / 2), 0);
+    porMembro[m.key] = tInd + tConj;
+  });
+
+  const totalEl   = document.getElementById('proxima-fatura-total');
+  const membrosEl = document.getElementById('proxima-fatura-membros');
+  if (totalEl) totalEl.textContent = formatarMoedaDash(total);
+  if (membrosEl && membros.length) {
+    membrosEl.innerHTML = membros.map(m =>
+      `${escHTML(m.nome.split(' ')[0])}: ${formatarMoedaDash(porMembro[m.key] ?? 0)}`
+    ).join(' · ');
+  }
 }

--- a/src/js/pages/fatura.js
+++ b/src/js/pages/fatura.js
@@ -29,6 +29,7 @@ let _catMap     = {};
 let _despesas   = [];        // despesas do mês filtradas pelo cartão
 let _cartaoId   = '';        // contaId do cartão selecionado
 let _tabAtiva   = 'todas';
+let _tabInicial = null;      // RF-065: tab a ativar na primeira renderização (via URL ?tab=)
 
 let _unsubContas        = null;
 let _unsubCats          = null;
@@ -71,6 +72,14 @@ onAuthChange(async (user) => {
 
 // ── Configuração de eventos ───────────────────────────────────
 function configurarEventos() {
+  // RF-065: se URL contém ?tab=projecoes (link do card Próxima Fatura no dashboard),
+  // ativar a tab Projeções na primeira renderização dos dados.
+  const tabParam = new URLSearchParams(window.location.search).get('tab');
+  if (['todas', 'projecoes', 'conjuntas', 'liquidacao'].includes(tabParam)) {
+    _tabAtiva   = tabParam;
+    _tabInicial = tabParam;
+  }
+
   document.getElementById('btn-mes-ant').addEventListener('click', () => {
     _mes--; if (_mes < 1) { _mes = 12; _ano--; }
     atualizarTituloMes();
@@ -185,6 +194,11 @@ function renderizarTudo() {
   document.getElementById('fat-resumo-cards').style.display = '';
   const conteudo = document.getElementById('fat-conteudo');
   if (conteudo) { conteudo.style.display = ''; conteudo.classList.add('fade-in'); }
+  // RF-065: ativar tab inicial (via ?tab= URL param) apenas uma vez
+  if (_tabInicial) {
+    ativarTab(_tabInicial);
+    _tabInicial = null;
+  }
 }
 
 // ── Membros do grupo ──────────────────────────────────────────


### PR DESCRIPTION
## O que foi feito

- **Card "Próxima Fatura" no dashboard**: novo card na grade de KPIs que exibe o total projetado para o próximo mês de faturamento, com breakdown por membro (Luigi / Ana). Visível apenas quando há `tipo='projecao'` com `mesFatura = mês corrente + 1`. Usa `valorAlocado` em conjuntas para evitar dupla contagem. Link direto para `fatura.html?tab=projecoes`.
- **Deep link `?tab=projecoes`**: `fatura.js` lê o URL param ao inicializar. Se válido, define `_tabAtiva` e ativa a tab na primeira renderização dos dados (one-time via flag `_tabInicial`). Whitelist de valores aceitos: `['todas', 'projecoes', 'conjuntas', 'liquidacao']`.

## Arquivos modificados

| Arquivo | Mudança |
|---|---|
| `src/dashboard.html` | Card `#card-proxima-fatura` na grade `resumo-cards` |
| `src/css/dashboard.css` | `.resumo-card--fatura::before` (amber via `--color-warning`) + `.proxima-fatura-link` |
| `src/js/app.js` | Import `ouvirDespesasPorMesFatura` + `escHTML`; `estadoApp.grupo`; `_unsubProxFatura`; `iniciarListenerProximaFatura()`; `renderizarCardProximaFatura()` |
| `src/js/pages/fatura.js` | `_tabInicial`; leitura de `?tab=` em `configurarEventos()`; ativação one-time em `renderizarTudo()` |

## Subagentes
- test-runner: **PASS** — 563/563 testes passando, build limpo
- security-reviewer: N/A (não tocou em auth/database/firestore.rules; `escHTML()` aplicado em todo `innerHTML` com dados do usuário)
- import-pipeline-reviewer: N/A (não tocou no pipeline de importação)

## Como testar
- [ ] `npm test` — 563 passando
- [ ] `npm run build` — sem erros
- [ ] No dashboard autenticado: se há projeções para o próximo mês → card "💳 Próxima Fatura" aparece com total e membros
- [ ] Se não há projeções → card permanece oculto
- [ ] Clicar "ver projeções →" → abre `fatura.html` com tab "📅 Projeções" ativa

## Checklist
- [x] Sem credenciais Firebase no diff
- [x] CSS usa variáveis de variables.css (`--color-warning`, `--color-primary`)
- [x] `chave_dedup` intacta (não tocada)
- [x] `mesFatura` propagado (lido via `ouvirDespesasPorMesFatura` — não criado)
- [x] `grupoId` presente em todas as queries Firestore (via `ouvirDespesasPorMesFatura`)
- [x] `escHTML()` em todo innerHTML com dados do usuário (nomes dos membros)
- [x] `onSnapshot`: `_unsubProxFatura` guardado para cleanup