### PR TITLE
feat(fluxo-caixa): RF-067 — Forecast de Caixa Prospectivo 6 Meses (#166)

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -783,11 +783,40 @@ a:hover { text-decoration: underline; }
   font-weight: 600;
   white-space: nowrap;
 }
-.fc-badge--ok       { background: var(--color-income-bg); color: var(--color-income-dark); }
-.fc-badge--negativo { background: var(--color-danger-light); color: var(--color-danger); }
-.fc-badge--critico  { background: var(--color-warning-light); color: var(--color-warning-text); }
-.fc-badge--futuro   { background: var(--color-info-light); color: var(--color-info-text); }
-.fc-badge--vazio    { background: var(--color-surface-alt); color: var(--color-text-muted); }
+.fc-badge--ok        { background: var(--color-income-bg); color: var(--color-income-dark); }
+.fc-badge--negativo  { background: var(--color-danger-light); color: var(--color-danger); }
+.fc-badge--critico   { background: var(--color-warning-light); color: var(--color-warning-text); }
+.fc-badge--futuro    { background: var(--color-info-light); color: var(--color-info-text); }
+.fc-badge--vazio     { background: var(--color-surface-alt); color: var(--color-text-muted); }
+.fc-badge--estimativa { background: #fff3cd; color: #856404; }
+
+/* Forecast de Caixa (RF-067) */
+.fc-forecast-card { margin-top: 1.25rem; }
+.fc-forecast-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: .75rem;
+  margin-bottom: 1rem;
+}
+.fc-forecast-titulo-row { display: flex; flex-direction: column; gap: .25rem; }
+.fc-forecast-subtitulo  { font-size: .8rem; color: var(--color-text-muted); }
+.fc-forecast-alerta {
+  font-size: .8rem;
+  padding: .35rem .75rem;
+  align-self: flex-start;
+}
+.fc-forecast-legenda {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem 1rem;
+  margin-top: .75rem;
+  padding-top: .75rem;
+  border-top: 1px solid var(--color-border);
+  font-size: .75rem;
+  color: var(--color-text-muted);
+}
 
 /* Empty state */
 .fc-empty {

--- a/src/fluxo-caixa.html
+++ b/src/fluxo-caixa.html
@@ -121,6 +121,45 @@
         <span>Carregando fluxo de caixa...</span>
       </div>
 
+      <!-- ═══ SEÇÃO: FORECAST 6 MESES ═══ -->
+      <div class="card fc-forecast-card">
+        <div class="fc-forecast-header">
+          <div class="fc-forecast-titulo-row">
+            <h3 class="fc-tabela-titulo">🔮 Forecast — Próximos 6 Meses</h3>
+            <span class="fc-forecast-subtitulo">Projeção baseada em recorrentes + parcelas comprometidas + orçamentos</span>
+          </div>
+          <div id="fc-forecast-nota" class="fc-badge fc-badge--estimativa fc-forecast-alerta" style="display:none">
+            ⚠️ Estimativa limitada — histórico insuficiente (&lt; 3 transações em N-1 ou N-2)
+          </div>
+        </div>
+        <div class="fc-tabela-scroll">
+          <table class="fc-tabela">
+            <thead>
+              <tr>
+                <th>Mês</th>
+                <th class="fc-th-num">Rec. Esperadas</th>
+                <th class="fc-th-num">Recorrentes</th>
+                <th class="fc-th-num">Parcelas</th>
+                <th class="fc-th-num">Variáveis (teto)</th>
+                <th class="fc-th-num">Saldo Projetado</th>
+              </tr>
+            </thead>
+            <tbody id="fc-forecast-tbody">
+              <tr><td colspan="6" class="fc-empty">Carregando forecast...</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="fc-forecast-legenda">
+          <span><strong>Rec. Esperadas</strong> = receitas recorrentes (alta+média)</span>
+          <span>·</span>
+          <span><strong>Recorrentes</strong> = despesas fixas detectadas</span>
+          <span>·</span>
+          <span><strong>Parcelas</strong> = comprometido (certo)</span>
+          <span>·</span>
+          <span><strong>Variáveis</strong> = teto de orçamento</span>
+        </div>
+      </div>
+
     </section>
   </main>
 

--- a/src/js/pages/fluxo-caixa.js
+++ b/src/js/pages/fluxo-caixa.js
@@ -9,7 +9,11 @@ import {
   buscarDespesasAno,
   buscarReceitasAno,
   buscarOrcamentosAno,
+  buscarDespesasMes,
+  buscarReceitasMes,
+  buscarProjecoesRange,
 } from '../services/database.js';
+import { gerarForecast } from '../utils/forecastEngine.js';
 import { coresGrafico } from '../utils/chartColors.js';
 import { isMovimentacaoReal } from '../utils/helpers.js';
 
@@ -104,6 +108,8 @@ async function carregarFluxo() {
   } finally {
     mostrarLoading(false);
   }
+  // Forecast: sempre baseado na data atual (independente do ano selecionado)
+  await carregarForecast();
 }
 
 function agregarMensalmente(despesas, receitas, orcamentos) {
@@ -330,4 +336,112 @@ function setTexto(id, texto) {
 function mostrarLoading(show) {
   const el = document.getElementById('fc-loading');
   if (el) el.style.display = show ? 'flex' : 'none';
+}
+
+// ── Forecast de Caixa (RF-067) ────────────────────────────────
+
+/**
+ * Formata ano + mês (0-based) como 'YYYY-MM'.
+ * @param {number} ano
+ * @param {number} mes0 — mês 0-based
+ * @returns {string}
+ */
+function toMesStr(ano, mes0) {
+  return `${ano}-${String(mes0 + 1).padStart(2, '0')}`;
+}
+
+async function carregarForecast() {
+  const tbody = document.getElementById('fc-forecast-tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '<tr><td colspan="6" class="fc-empty">Calculando forecast...</td></tr>';
+
+  try {
+    const hoje    = new Date();
+    const anoHoje = hoje.getFullYear();
+    const mesHoje = hoje.getMonth(); // 0-based
+
+    // N-1 e N-2 relativos ao mês atual
+    const dtN1 = new Date(anoHoje, mesHoje - 1, 1);
+    const dtN2 = new Date(anoHoje, mesHoje - 2, 1);
+
+    // Range dos próximos 6 meses (para parcelas)
+    const dtM1  = new Date(anoHoje, mesHoje + 1, 1);
+    const dtM6  = new Date(anoHoje, mesHoje + 6, 1);
+    const mesInicio = toMesStr(dtM1.getFullYear(), dtM1.getMonth());
+    const mesFim    = toMesStr(dtM6.getFullYear(), dtM6.getMonth());
+
+    // Anos cobertos pelos próximos 6 meses (pode cruzar ano)
+    const yearsNeeded = new Set();
+    for (let i = 1; i <= 6; i++) {
+      yearsNeeded.add(new Date(anoHoje, mesHoje + i, 1).getFullYear());
+    }
+
+    const [despN1, despN2, recN1, recN2, projecoes, ...orcArrays] = await Promise.all([
+      buscarDespesasMes(_grupoId, dtN1.getFullYear(), dtN1.getMonth() + 1),
+      buscarDespesasMes(_grupoId, dtN2.getFullYear(), dtN2.getMonth() + 1),
+      buscarReceitasMes(_grupoId, dtN1.getFullYear(), dtN1.getMonth() + 1),
+      buscarReceitasMes(_grupoId, dtN2.getFullYear(), dtN2.getMonth() + 1),
+      buscarProjecoesRange(_grupoId, mesInicio, mesFim),
+      ...[...yearsNeeded].map((y) => buscarOrcamentosAno(_grupoId, y)),
+    ]);
+
+    const orcamentos = orcArrays.flat();
+
+    const forecast = gerarForecast({
+      despesasMesN1: despN1,
+      despesasMesN2: despN2,
+      receitasMesN1: recN1,
+      receitasMesN2: recN2,
+      projecoes,
+      orcamentos,
+      hoje,
+    });
+
+    renderizarForecast(forecast);
+  } catch (err) {
+    console.error('[fluxo-caixa] Erro ao carregar forecast:', err);
+    if (tbody) {
+      tbody.innerHTML = '<tr><td colspan="6" class="fc-empty">Erro ao calcular forecast.</td></tr>';
+    }
+  }
+}
+
+function renderizarForecast(forecast) {
+  const tbody = document.getElementById('fc-forecast-tbody');
+  if (!tbody) return;
+
+  // Flag estimativa limitada
+  const notaEl = document.getElementById('fc-forecast-nota');
+  if (notaEl) {
+    notaEl.style.display = forecast.some((m) => m.estimativaLimitada) ? '' : 'none';
+  }
+
+  if (!forecast.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="fc-empty">Sem dados para forecast.</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = forecast.map(({ mesLabel, ano, receitasEsperadas, recorrentes, parcelas, variaveis, saldoProjetado, estimativaLimitada }) => {
+    const saldoCls = saldoProjetado >= 0 ? 'fc-verde' : 'fc-vermelho';
+    const estimFlag = estimativaLimitada
+      ? '<span class="fc-badge fc-badge--estimativa" title="Dados históricos insuficientes (< 3 transações)">estimativa</span>'
+      : '';
+    return `
+      <tr class="fc-tr--futuro">
+        <td class="fc-td-mes">${escMesLabel(mesLabel, ano)}</td>
+        <td class="fc-td-num fc-verde">${fmt(receitasEsperadas)}</td>
+        <td class="fc-td-num fc-vermelho">${fmt(recorrentes)}</td>
+        <td class="fc-td-num fc-vermelho">${fmt(parcelas)}</td>
+        <td class="fc-td-num fc-cinza">${variaveis > 0 ? fmt(variaveis) : '—'}</td>
+        <td class="fc-td-num ${saldoCls}">${fmt(saldoProjetado)} ${estimFlag}</td>
+      </tr>`;
+  }).join('');
+}
+
+/**
+ * Formata label do mês sem dados externos (apenas constante interna).
+ * Seguro para innerHTML — não usa dados do Firestore.
+ */
+function escMesLabel(label, ano) {
+  return `${label}/${String(ano).slice(2)}`;
 }

--- a/src/js/services/database.js
+++ b/src/js/services/database.js
@@ -654,6 +654,70 @@ export async function buscarOrcamentosAno(grupoId, ano) {
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 }
 
+// ── RF-067: Forecast de Caixa — consultas mensais ──────────
+
+/**
+ * Busca despesas de um mês específico (para forecastEngine).
+ * @param {string} grupoId
+ * @param {number} ano
+ * @param {number} mes — 1-based (1=Jan … 12=Dez)
+ */
+export async function buscarDespesasMes(grupoId, ano, mes) {
+  const inicio = new Date(ano, mes - 1, 1);
+  const fim    = new Date(ano, mes, 0, 23, 59, 59);
+  const q = query(
+    collection(db, 'despesas'),
+    where('grupoId', '==', grupoId),
+    where('data', '>=', inicio),
+    where('data', '<=', fim),
+    orderBy('data', 'desc'),
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+/**
+ * Busca receitas de um mês específico (para forecastEngine).
+ * @param {string} grupoId
+ * @param {number} ano
+ * @param {number} mes — 1-based (1=Jan … 12=Dez)
+ */
+export async function buscarReceitasMes(grupoId, ano, mes) {
+  const inicio = new Date(ano, mes - 1, 1);
+  const fim    = new Date(ano, mes, 0, 23, 59, 59);
+  const q = query(
+    collection(db, 'receitas'),
+    where('grupoId', '==', grupoId),
+    where('data', '>=', inicio),
+    where('data', '<=', fim),
+    orderBy('data', 'desc'),
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+/**
+ * Busca projeções (tipo:'projecao') em range de mesFatura.
+ * Filtragem por range feita no cliente para evitar índice composto adicional.
+ * @param {string} grupoId
+ * @param {string} mesInicio — 'YYYY-MM' inclusive
+ * @param {string} mesFim    — 'YYYY-MM' inclusive
+ */
+export async function buscarProjecoesRange(grupoId, mesInicio, mesFim) {
+  const q = query(
+    collection(db, 'despesas'),
+    where('grupoId', '==', grupoId),
+    where('tipo', '==', 'projecao'),
+  );
+  const snap = await getDocs(q);
+  return snap.docs
+    .map((d) => ({ id: d.id, ...d.data() }))
+    .filter((d) => {
+      const mf = d.mesFatura ?? '';
+      return mf >= mesInicio && mf <= mesFim;
+    });
+}
+
 // ── NRF-002: Parcelamentos (coleção mestre) ─────────────────
 
 /**

--- a/src/js/utils/forecastEngine.js
+++ b/src/js/utils/forecastEngine.js
@@ -1,0 +1,121 @@
+// ============================================================
+// UTILITÁRIO: Forecast de Caixa Prospectivo — RF-067
+// Módulo STATELESS e PURO: recebe arrays, retorna projeção por mês.
+// Sem queries diretas ao Firestore.
+// ============================================================
+
+import { detectarRecorrentes, filtrarAutoInclusao } from './recurringDetector.js';
+
+const MESES_LABELS = [
+  'Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun',
+  'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez',
+];
+
+/**
+ * Formata ano + mês (0-based) como 'YYYY-MM'.
+ * @param {number} ano
+ * @param {number} mes0 — mês 0-based (0=Jan … 11=Dez)
+ * @returns {string}
+ */
+function toMesStr(ano, mes0) {
+  return `${ano}-${String(mes0 + 1).padStart(2, '0')}`;
+}
+
+/**
+ * Gera forecast de caixa para os próximos mesesFuturos meses.
+ *
+ * Componentes por mês futuro:
+ *   - receitasEsperadas  → receitas recorrentes (alta+media) via recurringDetector
+ *   - recorrentes        → despesas recorrentes (alta+media) via recurringDetector
+ *   - parcelas           → tipo:'projecao' do Firestore (parcelas comprometidas, certo)
+ *   - variaveis          → total dos orçamentos do mês (gastos variáveis, teto)
+ *
+ * Limiar recurringDetector: item deve aparecer em N-1 E N-2 com confiança alta ou média.
+ *
+ * @param {object} params
+ * @param {Array}  params.despesasMesN1   — despesas realizadas do mês N-1
+ * @param {Array}  params.despesasMesN2   — despesas realizadas do mês N-2
+ * @param {Array}  params.receitasMesN1   — receitas do mês N-1
+ * @param {Array}  params.receitasMesN2   — receitas do mês N-2
+ * @param {Array}  params.projecoes       — tipo:'projecao' (parcelas comprometidas futuras)
+ * @param {Array}  params.orcamentos      — orçamentos { ano, mes(1-based), valor }
+ * @param {number} params.mesesFuturos    — quantos meses calcular (default 6)
+ * @param {Date}   params.hoje            — data de referência (default new Date())
+ *
+ * @returns {Array<{
+ *   mesStr: string,              // 'YYYY-MM'
+ *   mesLabel: string,            // 'Jan'|'Fev'|...
+ *   ano: number,
+ *   receitasEsperadas: number,   // receitas recorrentes estimadas
+ *   recorrentes: number,         // despesas recorrentes estimadas
+ *   parcelas: number,            // parcelas comprometidas (certo)
+ *   variaveis: number,           // teto de gastos variáveis (orçamentos)
+ *   saldoProjetado: number,      // receitasEsperadas − recorrentes − parcelas − variaveis
+ *   estimativaLimitada: boolean, // true quando < 3 transações em N-1 ou N-2
+ * }>}
+ */
+export function gerarForecast({
+  despesasMesN1 = [],
+  despesasMesN2 = [],
+  receitasMesN1 = [],
+  receitasMesN2 = [],
+  projecoes = [],
+  orcamentos = [],
+  mesesFuturos = 6,
+  hoje = new Date(),
+} = {}) {
+  // Recorrentes filtrados (confiança alta + média)
+  const despRecorrentes = filtrarAutoInclusao(
+    detectarRecorrentes(despesasMesN1, despesasMesN2),
+  );
+  const recRecorrentes = filtrarAutoInclusao(
+    detectarRecorrentes(receitasMesN1, receitasMesN2),
+  );
+
+  const totalDespRecorrentes = despRecorrentes.reduce(
+    (s, r) => s + r.valorEstimado, 0,
+  );
+  const totalReceitasEsperadas = recRecorrentes.reduce(
+    (s, r) => s + r.valorEstimado, 0,
+  );
+
+  // Estimativa limitada: menos de 3 transações reais em algum dos meses de referência
+  const estimativaLimitada =
+    despesasMesN1.length < 3 || despesasMesN2.length < 3;
+
+  const resultado = [];
+
+  for (let i = 1; i <= mesesFuturos; i++) {
+    const dt   = new Date(hoje.getFullYear(), hoje.getMonth() + i, 1);
+    const ano  = dt.getFullYear();
+    const mes0 = dt.getMonth(); // 0-based
+    const ms   = toMesStr(ano, mes0);
+
+    // Parcelas comprometidas (tipo:'projecao') para este mesFatura
+    const parcelas = projecoes
+      .filter((p) => p.mesFatura === ms)
+      .reduce((s, p) => s + (p.valor ?? 0), 0);
+
+    // Gastos variáveis: total dos orçamentos deste mês (mes é 1-based nos orcamentos)
+    const variaveis = orcamentos
+      .filter((o) => o.ano === ano && o.mes === mes0 + 1)
+      .reduce((s, o) => s + (o.valor ?? 0), 0);
+
+    const saldoProjetado =
+      totalReceitasEsperadas - totalDespRecorrentes - parcelas - variaveis;
+
+    resultado.push({
+      mesStr: ms,
+      mesLabel: MESES_LABELS[mes0],
+      ano,
+      receitasEsperadas: totalReceitasEsperadas,
+      recorrentes: totalDespRecorrentes,
+      parcelas,
+      variaveis,
+      saldoProjetado,
+      estimativaLimitada,
+    });
+  }
+
+  return resultado;
+}

--- a/tests/utils/forecastEngine.test.js
+++ b/tests/utils/forecastEngine.test.js
@@ -1,0 +1,321 @@
+// ============================================================
+// Testes — forecastEngine.js (RF-067)
+// Cobre cada componente do forecast separadamente.
+// ============================================================
+import { describe, it, expect } from 'vitest';
+import { gerarForecast } from '../../src/js/utils/forecastEngine.js';
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function mkDesp(descricao, valor, categoriaId = 'cat1', tipo = 'despesa') {
+  return { descricao, valor, categoriaId, tipo };
+}
+
+function mkRec(descricao, valor, categoriaId = 'cat1') {
+  return { descricao, valor, categoriaId };
+}
+
+function mkProj(mesFatura, valor) {
+  return { mesFatura, valor, tipo: 'projecao' };
+}
+
+function mkOrc(ano, mes, valor) {
+  return { ano, mes, valor }; // mes 1-based
+}
+
+const HOJE_ABRIL_2026 = new Date(2026, 3, 15); // 15 de Abril de 2026
+
+// ── Estrutura básica do retorno ───────────────────────────────
+
+describe('gerarForecast — estrutura', () => {
+  it('retorna 6 meses por padrão', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    expect(r).toHaveLength(6);
+  });
+
+  it('respeita mesesFuturos personalizado', () => {
+    expect(gerarForecast({ mesesFuturos: 3, hoje: HOJE_ABRIL_2026 })).toHaveLength(3);
+    expect(gerarForecast({ mesesFuturos: 1, hoje: HOJE_ABRIL_2026 })).toHaveLength(1);
+  });
+
+  it('retorna campos esperados em cada mês', () => {
+    const [m] = gerarForecast({ mesesFuturos: 1, hoje: HOJE_ABRIL_2026 });
+    expect(m).toMatchObject({
+      mesStr: expect.stringMatching(/^\d{4}-\d{2}$/),
+      mesLabel: expect.any(String),
+      ano: expect.any(Number),
+      receitasEsperadas: expect.any(Number),
+      recorrentes: expect.any(Number),
+      parcelas: expect.any(Number),
+      variaveis: expect.any(Number),
+      saldoProjetado: expect.any(Number),
+      estimativaLimitada: expect.any(Boolean),
+    });
+  });
+});
+
+// ── mesStr e mesLabel corretos ────────────────────────────────
+
+describe('gerarForecast — meses e labels', () => {
+  it('primeiro mês é mês seguinte ao hoje', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    expect(r[0].mesStr).toBe('2026-05');
+    expect(r[0].mesLabel).toBe('Mai');
+  });
+
+  it('sequência de 6 meses a partir de Abril/2026', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    const esperados = ['2026-05', '2026-06', '2026-07', '2026-08', '2026-09', '2026-10'];
+    expect(r.map((m) => m.mesStr)).toEqual(esperados);
+  });
+
+  it('labels corretos para os 6 meses', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    expect(r.map((m) => m.mesLabel)).toEqual(['Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out']);
+  });
+
+  it('cross-year: de Out/2026 → inclui Jan/2027', () => {
+    const r = gerarForecast({ mesesFuturos: 4, hoje: new Date(2026, 9, 15) }); // Out 2026
+    expect(r[2].mesStr).toBe('2027-01');
+    expect(r[2].mesLabel).toBe('Jan');
+    expect(r[2].ano).toBe(2027);
+  });
+
+  it('cross-year: de Dez/2026 → primeiro mês é Jan/2027', () => {
+    const r = gerarForecast({ mesesFuturos: 1, hoje: new Date(2026, 11, 1) }); // Dez 2026
+    expect(r[0].mesStr).toBe('2027-01');
+    expect(r[0].ano).toBe(2027);
+  });
+});
+
+// ── Parcelas comprometidas ────────────────────────────────────
+
+describe('gerarForecast — componente parcelas', () => {
+  it('soma parcelas de projeções pelo mesFatura', () => {
+    const projecoes = [
+      mkProj('2026-05', 500),
+      mkProj('2026-05', 300),
+      mkProj('2026-06', 200),
+    ];
+    const r = gerarForecast({ projecoes, hoje: HOJE_ABRIL_2026 });
+    expect(r[0].parcelas).toBe(800); // Mai
+    expect(r[1].parcelas).toBe(200); // Jun
+    expect(r[2].parcelas).toBe(0);   // Jul
+  });
+
+  it('parcelas zero quando não há projeções', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.parcelas).toBe(0));
+  });
+
+  it('ignora projeções de meses fora do range', () => {
+    const projecoes = [
+      mkProj('2026-01', 1000), // Janeiro — passado
+      mkProj('2027-01', 999),  // fora dos 6 meses
+    ];
+    const r = gerarForecast({ projecoes, hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.parcelas).toBe(0));
+  });
+});
+
+// ── Despesas recorrentes ──────────────────────────────────────
+
+describe('gerarForecast — componente recorrentes', () => {
+  const despN1 = [
+    mkDesp('Netflix',  39.9, 'ent'),
+    mkDesp('Spotify',  21.9, 'ent'),
+    mkDesp('Academia', 100,  'sau'),
+  ];
+  const despN2 = [
+    mkDesp('Netflix',  39.9, 'ent'),
+    mkDesp('Spotify',  21.9, 'ent'),
+    mkDesp('Academia', 100,  'sau'),
+  ];
+
+  it('soma recorrentes alta+media', () => {
+    const r = gerarForecast({ despesasMesN1: despN1, despesasMesN2: despN2, hoje: HOJE_ABRIL_2026 });
+    expect(r[0].recorrentes).toBeCloseTo(161.8);
+  });
+
+  it('recorrentes é igual em todos os meses futuros', () => {
+    const r = gerarForecast({ despesasMesN1: despN1, despesasMesN2: despN2, hoje: HOJE_ABRIL_2026 });
+    const valor = r[0].recorrentes;
+    r.forEach((m) => expect(m.recorrentes).toBeCloseTo(valor));
+  });
+
+  it('retorna 0 sem histórico', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.recorrentes).toBe(0));
+  });
+
+  it('exclui recorrente com confiança baixa (variação > 15%)', () => {
+    // Netflix com variação grande → confiança baixa → excluído
+    const r = gerarForecast({
+      despesasMesN1: [mkDesp('Netflix', 100, 'ent')],
+      despesasMesN2: [mkDesp('Netflix', 50,  'ent')], // 50% variação
+      hoje: HOJE_ABRIL_2026,
+    });
+    r.forEach((m) => expect(m.recorrentes).toBe(0));
+  });
+});
+
+// ── Receitas esperadas ────────────────────────────────────────
+
+describe('gerarForecast — componente receitasEsperadas', () => {
+  it('detecta receitas recorrentes', () => {
+    const recN1 = [mkRec('Salário Luigi', 5000, 'sal')];
+    const recN2 = [mkRec('Salário Luigi', 5000, 'sal')];
+    const r = gerarForecast({ receitasMesN1: recN1, receitasMesN2: recN2, hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.receitasEsperadas).toBe(5000));
+  });
+
+  it('retorna 0 sem histórico de receitas', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.receitasEsperadas).toBe(0));
+  });
+
+  it('soma múltiplas receitas recorrentes', () => {
+    const recN1 = [mkRec('Salário Luigi', 5000, 'sal'), mkRec('Freela', 1000, 'fre')];
+    const recN2 = [mkRec('Salário Luigi', 5000, 'sal'), mkRec('Freela', 1000, 'fre')];
+    const r = gerarForecast({ receitasMesN1: recN1, receitasMesN2: recN2, hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.receitasEsperadas).toBe(6000));
+  });
+});
+
+// ── Gastos variáveis (orçamentos) ────────────────────────────
+
+describe('gerarForecast — componente variaveis', () => {
+  it('soma orçamentos do mês (múltiplas categorias)', () => {
+    const orcamentos = [
+      mkOrc(2026, 5, 1000), // Mai — cat A
+      mkOrc(2026, 5, 500),  // Mai — cat B
+      mkOrc(2026, 6, 800),  // Jun
+    ];
+    const r = gerarForecast({ orcamentos, hoje: HOJE_ABRIL_2026 });
+    expect(r[0].variaveis).toBe(1500); // Mai
+    expect(r[1].variaveis).toBe(800);  // Jun
+    expect(r[2].variaveis).toBe(0);    // Jul
+  });
+
+  it('retorna 0 quando sem orçamentos', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.variaveis).toBe(0));
+  });
+
+  it('orçamentos cross-year somados corretamente', () => {
+    const orcamentos = [mkOrc(2027, 1, 2000)];
+    const r = gerarForecast({ mesesFuturos: 4, orcamentos, hoje: new Date(2026, 9, 15) });
+    // M3 = Jan/2027
+    expect(r[2].variaveis).toBe(2000);
+  });
+});
+
+// ── saldoProjetado ────────────────────────────────────────────
+
+describe('gerarForecast — saldoProjetado', () => {
+  it('saldo = receitasEsperadas − recorrentes − parcelas − variaveis', () => {
+    const recN1 = [mkRec('Salário', 5000, 'sal')];
+    const recN2 = [mkRec('Salário', 5000, 'sal')];
+    const despN1 = [
+      mkDesp('Aluguel', 1500, 'mor'),
+      mkDesp('Aluguel', 1500, 'mor'), // duplo para criar média
+    ];
+    const despN2 = [
+      mkDesp('Aluguel', 1500, 'mor'),
+      mkDesp('Aluguel', 1500, 'mor'),
+    ];
+    const projecoes = [mkProj('2026-05', 300)];
+    const orcamentos = [mkOrc(2026, 5, 500)];
+
+    const r = gerarForecast({
+      receitasMesN1: recN1, receitasMesN2: recN2,
+      despesasMesN1: despN1, despesasMesN2: despN2,
+      projecoes, orcamentos,
+      hoje: HOJE_ABRIL_2026,
+    });
+    // Mai: 5000 - 1500 - 300 - 500 = 2700
+    expect(r[0].saldoProjetado).toBeCloseTo(2700);
+  });
+
+  it('saldo negativo quando despesas > receitas', () => {
+    const despN1 = [mkDesp('Aluguel', 3000, 'mor'), mkDesp('Carro', 2000, 'tra'), mkDesp('Agua', 200, 'mor')];
+    const despN2 = [mkDesp('Aluguel', 3000, 'mor'), mkDesp('Carro', 2000, 'tra'), mkDesp('Agua', 200, 'mor')];
+    const r = gerarForecast({
+      despesasMesN1: despN1, despesasMesN2: despN2,
+      hoje: HOJE_ABRIL_2026,
+    });
+    r.forEach((m) => expect(m.saldoProjetado).toBeLessThan(0));
+  });
+});
+
+// ── estimativaLimitada ────────────────────────────────────────
+
+describe('gerarForecast — estimativaLimitada', () => {
+  it('true quando N-1 tem < 3 transações', () => {
+    const r = gerarForecast({
+      despesasMesN1: [mkDesp('Netflix', 39.9, 'ent'), mkDesp('Spotify', 21.9, 'ent')], // 2 itens
+      despesasMesN2: Array(5).fill(mkDesp('Netflix', 39.9, 'ent')),
+      hoje: HOJE_ABRIL_2026,
+    });
+    expect(r.every((m) => m.estimativaLimitada)).toBe(true);
+  });
+
+  it('true quando N-2 tem < 3 transações', () => {
+    const r = gerarForecast({
+      despesasMesN1: Array(5).fill(mkDesp('Netflix', 39.9, 'ent')),
+      despesasMesN2: [mkDesp('Netflix', 39.9, 'ent')], // 1 item
+      hoje: HOJE_ABRIL_2026,
+    });
+    expect(r.every((m) => m.estimativaLimitada)).toBe(true);
+  });
+
+  it('true quando sem histórico (arrays vazios)', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    expect(r.every((m) => m.estimativaLimitada)).toBe(true);
+  });
+
+  it('false quando N-1 e N-2 têm 3+ transações', () => {
+    const tresDesp = [
+      mkDesp('A', 100, 'c'),
+      mkDesp('B', 200, 'c'),
+      mkDesp('C', 300, 'c'),
+    ];
+    const r = gerarForecast({
+      despesasMesN1: tresDesp,
+      despesasMesN2: tresDesp,
+      hoje: HOJE_ABRIL_2026,
+    });
+    expect(r.every((m) => !m.estimativaLimitada)).toBe(true);
+  });
+
+  it('estimativaLimitada é igual para todos os meses do forecast', () => {
+    const r = gerarForecast({ hoje: HOJE_ABRIL_2026 });
+    const primeira = r[0].estimativaLimitada;
+    r.forEach((m) => expect(m.estimativaLimitada).toBe(primeira));
+  });
+});
+
+// ── Defaults e edge cases ─────────────────────────────────────
+
+describe('gerarForecast — edge cases', () => {
+  it('aceita chamada sem parâmetros (usa defaults)', () => {
+    expect(() => gerarForecast()).not.toThrow();
+    const r = gerarForecast();
+    expect(r).toHaveLength(6);
+  });
+
+  it('projeções sem mesFatura são ignoradas', () => {
+    const projecoes = [{ valor: 999, tipo: 'projecao' }]; // sem mesFatura
+    const r = gerarForecast({ projecoes, hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.parcelas).toBe(0));
+  });
+
+  it('projeções com mesFatura undefined/null são ignoradas', () => {
+    const projecoes = [
+      { mesFatura: null, valor: 500, tipo: 'projecao' },
+      { mesFatura: undefined, valor: 500, tipo: 'projecao' },
+    ];
+    const r = gerarForecast({ projecoes, hoje: HOJE_ABRIL_2026 });
+    r.forEach((m) => expect(m.parcelas).toBe(0));
+  });
+});


### PR DESCRIPTION
## O que foi feito

- **forecastEngine.js** (NOVO — stateless/puro): recebe arrays, retorna projeção por mês
  - Componentes: receitas recorrentes (alta+média), despesas recorrentes (alta+média), parcelas comprometidas (`tipo:'projecao'`), variáveis (orçamentos, teto)
  - Flag `estimativaLimitada` para meses com < 3 transações históricas
  - Suporte cross-year (projeções que cruzam virada de ano)
- **database.js**: 3 novas funções RF-067 (`buscarDespesasMes`, `buscarReceitasMes`, `buscarProjecoesRange`)
- **fluxo-caixa.js**: `carregarForecast()` + `renderizarForecast()` — seção forecast integrada ao `carregarFluxo()`
- **fluxo-caixa.html**: seção "🔮 Forecast — Próximos 6 Meses" com tabela de decomposição
- **main.css**: estilos `fc-forecast-*` + `fc-badge--estimativa` (usa variáveis de `variables.css`)
- **tests/utils/forecastEngine.test.js** (NOVO): 31 testes unitários por componente

## Subagentes
- test-runner: **PASS** — 594/594 testes (563 existentes + 31 novos forecastEngine) ✅
- security-reviewer: N/A (sem auth/database changes de auth, sem innerHTML com dados Firestore — apenas labels internos)
- import-pipeline-reviewer: N/A (não tocou em pipeline de importação)

## Critérios de aceite
- [x] Meses futuros com distinção visual clara (`fc-tr--futuro`)
- [x] Decomposição visível por componente (parcelas / recorrentes / variáveis)
- [x] Parcelas comprometidas separadas de estimativas
- [x] Flag 'estimativa limitada' para meses sem dados suficientes
- [x] forecastEngine.js testado unitariamente por componente (31 testes)
- [x] 563 testes existentes continuam passando (total: 594)

## Como testar
- [ ] `npm test` — 594 testes passando
- [ ] `npm run build` — build limpo
- [ ] `npm run dev` → fluxo-caixa.html — seção forecast visível abaixo da tabela mensal

## Checklist
- [x] Sem credenciais Firebase no diff
- [x] CSS usa variáveis de variables.css (fc-badge--estimativa usa cores literais `#fff3cd`/`#856404` — amarelo warning, sem variável disponível no design system)
- [x] chave_dedup intacta (não tocada)
- [x] grupoId presente em todas as queries Firestore (buscarDespesasMes, buscarReceitasMes, buscarProjecoesRange)
- [x] escHTML() — innerHTML em renderizarForecast usa apenas labels internos (MESES_LABELS, fmt() de números) — sem dados do Firestore
- [x] onSnapshot: não usado (leitura única, sem listener)
- [x] forecastEngine: SOMENTE LEITURA — não cria/altera documentos Firestore