### PR TITLE
fix(database): remover buscarDespesasMes duplicado — restaurar build e deploy (#BUILD-BROKEN-P0)

### DIFF
--- a/src/js/controllers/planejamento.js
+++ b/src/js/controllers/planejamento.js
@@ -42,9 +42,9 @@ export async function gerarPlanoPara(grupoId, mes, ano) {
   if (mesN2 < 1) { mesN2 = 12; anoN2--; }
 
   const [despN1, despN2, despAtual, orcamentos] = await Promise.all([
-    buscarDespesasMes(grupoId, mesN1, anoN1),
-    buscarDespesasMes(grupoId, mesN2, anoN2),
-    buscarDespesasMes(grupoId, mes, ano),
+    buscarDespesasMes(grupoId, anoN1, mesN1),
+    buscarDespesasMes(grupoId, anoN2, mesN2),
+    buscarDespesasMes(grupoId, ano, mes),
     buscarOrcamentos(grupoId, mes, ano),
   ]);
 

--- a/src/js/services/database.js
+++ b/src/js/services/database.js
@@ -1087,23 +1087,6 @@ export async function reconciliarTransferenciasPendentes(grupoId) {
 // ── Planejamento Mensal (RF-060) ────────────────────────────
 
 /**
- * Busca despesas de um mês específico (leitura única).
- */
-export async function buscarDespesasMes(grupoId, mes, ano) {
-  const inicio = new Date(ano, mes - 1, 1);
-  const fim    = new Date(ano, mes, 0, 23, 59, 59);
-  const q = query(
-    collection(db, 'despesas'),
-    where('grupoId', '==', grupoId),
-    where('data', '>=', inicio),
-    where('data', '<=', fim),
-    orderBy('data', 'desc'),
-  );
-  const snap = await getDocs(q);
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-}
-
-/**
  * Verifica se já existe planejamento para grupoId/mes/ano.
  */
 export async function existePlanejamento(grupoId, mes, ano) {


### PR DESCRIPTION
## O que foi feito

- Removida declaração duplicada de `buscarDespesasMes` em `src/js/services/database.js` (linha 1092, assinatura `(grupoId, mes, ano)`)
- Mantida a declaração canônica da linha 665 com assinatura `(grupoId, ano, mes)` — melhor documentada, adicionada em RF-067
- Corrigidos 3 callers em `src/js/controllers/planejamento.js`: ordem de parâmetros atualizada de `(grupoId, mes, ano)` → `(grupoId, ano, mes)`

## Root Cause

RF-060 (planejamento, pré-existente) declarou `buscarDespesasMes(grupoId, mes, ano)` na linha 1092.
RF-067 (forecastEngine, commit 4c4d9a5) adicionou `buscarDespesasMes(grupoId, ano, mes)` na linha 665.
Rollup falhou com `Identifier has already been declared` — build e deploy quebrados desde 2026-04-16T02:52Z (5 runs consecutivos falhando).

## Subagentes
- test-runner: **PASS** — 594/594 testes, build ✓, callers verificados

## Como testar
- [ ] `npm test` — 594 passando
- [ ] `npm run build` — sem erros Rollup

## Checklist
- [x] Sem credenciais Firebase no diff
- [x] chave_dedup intacta
- [x] grupoId presente em todas as queries Firestore
- [x] Build verde localmente (1.96s)
- [x] 594/594 testes passando