### PR TITLE
feat(dashboard): RF-068 — Saldo Real por Conta (#169)

### DIFF
--- a/src/contas.html
+++ b/src/contas.html
@@ -78,6 +78,33 @@
 
   </main>
 
+  <!-- RF-068: Modal Saldo Inicial (banco/dinheiro) -->
+  <div id="modal-saldo-banco" class="modal hidden">
+    <div class="modal-content" style="max-width:400px;">
+      <div class="modal-header">
+        <h3 id="modal-saldo-titulo">Configurar Saldo</h3>
+        <button id="btn-fechar-modal-saldo" class="modal-close">&times;</button>
+      </div>
+      <p style="font-size:.87rem;color:var(--text-muted);margin-bottom:1rem;">
+        Informe o saldo atual da conta e a data de referência. O app calculará o saldo real somando receitas e subtraindo despesas a partir dessa data.
+      </p>
+      <form id="form-saldo-banco" autocomplete="off">
+        <div class="form-group">
+          <label for="inp-saldo-inicial">Saldo atual (R$) *</label>
+          <input id="inp-saldo-inicial" class="form-input" type="number" step="0.01" placeholder="Ex: 3500.00" required />
+        </div>
+        <div class="form-group">
+          <label for="inp-data-referencia">Data de referência *</label>
+          <input id="inp-data-referencia" class="form-input" type="date" required />
+        </div>
+        <div class="modal-footer" style="margin-top:1rem;">
+          <button type="button" id="btn-cancelar-saldo" class="btn btn-outline">Cancelar</button>
+          <button type="submit" class="btn btn-primary">Salvar Saldo</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <!-- Modal: Criar/Editar Cartão -->
   <div id="modal-cartao" class="modal hidden">
     <div class="modal-content" style="max-width:520px;">

--- a/src/css/dashboard.css
+++ b/src/css/dashboard.css
@@ -94,6 +94,23 @@
 .resumo-card--meu-bolso::before { background: var(--color-budget); opacity: 1; }
 .resumo-card--familia::before   { background: var(--color-ok); opacity: 1; }
 .resumo-card--fatura::before    { background: var(--color-warning); opacity: 1; }
+.resumo-card--saldo-real::before { background: #0284c7; opacity: 1; } /* RF-068: saldo real — azul */
+
+/* RF-068: detalhes por conta no card Saldo Real */
+.saldo-real-detalhes {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.saldo-real-linha {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  gap: var(--space-3);
+}
+.saldo-real-linha--negativo { color: var(--color-expense); font-weight: 600; }
 
 .proxima-fatura-link {
   font-size: var(--font-size-xs);

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -91,6 +91,13 @@
           <span class="resumo-valor" id="total-familia">R$ 0,00</span>
           <span class="resumo-sublabel">total conjunto do grupo</span>
         </div>
+        <!-- RF-068: card Saldo Real por Conta (visível apenas quando há contas com saldoInicial configurado) -->
+        <div class="card resumo-card resumo-card--saldo-real" id="card-saldo-real" style="display:none;">
+          <span class="resumo-label">🏦 Saldo Real</span>
+          <span class="resumo-valor" id="saldo-real-consolidado">R$ 0,00</span>
+          <span class="resumo-sublabel">total contas bancárias</span>
+          <div id="saldo-real-detalhes" class="saldo-real-detalhes"></div>
+        </div>
         <!-- RF-065: card Próxima Fatura (visível apenas quando há projeções para o próximo mês) -->
         <div class="card resumo-card resumo-card--fatura" id="card-proxima-fatura" style="display:none;">
           <span class="resumo-label">💳 Próxima Fatura</span>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -18,6 +18,9 @@ import {
   buscarReceitasPeriodo,      // RF-017: gráficos
   buscarDespesasAno,          // RF-017: filtro anual
   buscarReceitasAno,          // RF-017: filtro anual
+  ouvirContas,                // RF-068: saldo real por conta
+  ouvirDespesasDesdeData,     // RF-068
+  ouvirReceitasDesdeData,     // RF-068
 } from './services/database.js';
 import { iniciarListenerCategorias } from './controllers/categorias.js';
 import {
@@ -57,6 +60,13 @@ let _unsubProj        = null; // RF-014: parcelamentos em aberto
 let _unsubRec         = null; // receitas do mês
 let _unsubCatRec      = null; // categorias de receita
 let _unsubProxFatura  = null; // RF-065: card Próxima Fatura
+// RF-068: saldo real por conta
+let _unsubContas      = null;
+let _unsubDespSaldo   = null;
+let _unsubRecSaldo    = null;
+let _contasAtivas     = [];
+let _despesasSaldo    = [];
+let _receitasSaldo    = [];
 
 // ── RF-017: Gráficos ──────────────────────────────────────────
 const MESES_ABREV = ['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','Nov','Dez'];
@@ -115,6 +125,7 @@ onAuthChange(async (user) => {
   iniciarListenerParcelamentos(estadoApp.perfil.grupoId);   // RF-014
   iniciarListenerCategoriasReceita(estadoApp.perfil.grupoId);
   iniciarListenerProximaFatura(estadoApp.perfil.grupoId);   // RF-065
+  iniciarListenerSaldoReal(estadoApp.perfil.grupoId);       // RF-068
   garantirCategoriasReceita(estadoApp.perfil.grupoId, CATEGORIAS_RECEITA_PADRAO).catch(() => {});
   garantirContasPadrao(estadoApp.perfil.grupoId, CONTAS_PADRAO).catch(() => {}); // NRF-004
   migrarCartaoGenerico(estadoApp.perfil.grupoId).catch(() => {}); // RF-062: marca cartão genérico como _legado
@@ -629,6 +640,98 @@ function iniciarListenerProximaFatura(grupoId) {
     const projecoes = despesas.filter(d => d.tipo === 'projecao');
     renderizarCardProximaFatura(projecoes);
   });
+}
+
+// ── RF-068: Saldo Real por Conta ──────────────────────────────
+
+function iniciarListenerSaldoReal(grupoId) {
+  if (_unsubContas) _unsubContas();
+
+  _unsubContas = ouvirContas(grupoId, (contas) => {
+    _contasAtivas = contas.filter(c => c.tipo !== 'cartao' && c.saldoInicial != null && c.dataReferenciaSaldo);
+
+    if (!_contasAtivas.length) {
+      const card = document.getElementById('card-saldo-real');
+      if (card) card.style.display = 'none';
+      return;
+    }
+
+    // Data de referência mais antiga entre todas as contas com saldo configurado
+    const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+    const dataMinIso = _contasAtivas
+      .map(c => c.dataReferenciaSaldo)
+      .filter(d => ISO_DATE_RE.test(d))
+      .sort()[0];
+    if (!dataMinIso) return;
+    const dataMin = new Date(dataMinIso + 'T00:00:00');
+
+    if (_unsubDespSaldo) _unsubDespSaldo();
+    if (_unsubRecSaldo)  _unsubRecSaldo();
+
+    _unsubDespSaldo = ouvirDespesasDesdeData(grupoId, dataMin, (desp) => {
+      _despesasSaldo = desp;
+      renderizarCardSaldoReal();
+    });
+    _unsubRecSaldo = ouvirReceitasDesdeData(grupoId, dataMin, (recs) => {
+      _receitasSaldo = recs;
+      renderizarCardSaldoReal();
+    });
+  });
+}
+
+function renderizarCardSaldoReal() {
+  const card = document.getElementById('card-saldo-real');
+  if (!card || !_contasAtivas.length) return;
+
+  const fmt = (v) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
+
+  // Calcula saldo real por conta
+  const saldosPorConta = _contasAtivas.map((conta) => {
+    const dataRef = new Date(conta.dataReferenciaSaldo + 'T00:00:00');
+
+    const totalDesp = _despesasSaldo
+      .filter(d => {
+        if (!d.contaId || d.contaId !== conta.id) return false;
+        // RN3: apenas movimentações reais
+        if (d.tipo === 'projecao' || d.tipo === 'projecao_paga' || d.tipo === 'transferencia_interna') return false;
+        const dt = d.data?.toDate?.() ?? new Date(d.data);
+        return dt >= dataRef;
+      })
+      .reduce((s, d) => s + (d.valor ?? 0), 0);
+
+    const totalRec = _receitasSaldo
+      .filter(r => {
+        if (!r.contaId || r.contaId !== conta.id) return false;
+        const dt = r.data?.toDate?.() ?? new Date(r.data);
+        return dt >= dataRef;
+      })
+      .reduce((s, r) => s + (r.valor ?? 0), 0);
+
+    const saldo = (conta.saldoInicial ?? 0) + totalRec - totalDesp;
+    return { conta, saldo };
+  });
+
+  const totalConsolidado = saldosPorConta.reduce((s, x) => s + x.saldo, 0);
+
+  const totalEl    = document.getElementById('saldo-real-consolidado');
+  const detalhesEl = document.getElementById('saldo-real-detalhes');
+
+  if (totalEl) {
+    totalEl.textContent = fmt(totalConsolidado);
+    totalEl.style.color = totalConsolidado < 0 ? 'var(--color-expense)' : '';
+  }
+
+  if (detalhesEl) {
+    detalhesEl.innerHTML = saldosPorConta.map(({ conta, saldo }) => {
+      const negativo = saldo < 0 ? ' saldo-real-linha--negativo' : '';
+      return `<div class="saldo-real-linha${negativo}">
+        <span>${escHTML(conta.emoji)} ${escHTML(conta.nome)}</span>
+        <span>${escHTML(fmt(saldo))}</span>
+      </div>`;
+    }).join('');
+  }
+
+  card.style.display = '';
 }
 
 function renderizarCardProximaFatura(projecoes) {

--- a/src/js/models/Conta.js
+++ b/src/js/models/Conta.js
@@ -25,6 +25,12 @@ export function modelConta(dados) {
     ativa:   dados.ativa   !== false,    // default true
   };
 
+  // RF-068: campos de saldo para contas bancárias e dinheiro
+  if (base.tipo !== 'cartao') {
+    base.saldoInicial        = dados.saldoInicial != null ? Number(dados.saldoInicial) : 0;
+    base.dataReferenciaSaldo = dados.dataReferenciaSaldo ?? null;
+  }
+
   // RF-062: campos adicionais para cartões de crédito
   if (base.tipo === 'cartao') {
     if (dados.bandeira)        base.bandeira        = dados.bandeira;

--- a/src/js/pages/contas.js
+++ b/src/js/pages/contas.js
@@ -121,6 +121,9 @@ function renderizarListas() {
   cartoesEl.querySelectorAll('.btn-desativar-cartao').forEach(btn => {
     btn.addEventListener('click', () => desativarConta(btn.dataset.id));
   });
+  bancosEl.querySelectorAll('.btn-editar-saldo').forEach(btn => {
+    btn.addEventListener('click', () => abrirModalSaldo(btn.dataset.id));
+  });
 }
 
 function renderCartao(c) {
@@ -151,18 +154,67 @@ function renderCartao(c) {
 
 function renderBanco(c) {
   const legadoTag = c._legado ? ' <span style="font-size:.75rem;background:var(--warning-bg,#fff3cd);padding:2px 6px;border-radius:4px;">legado</span>' : '';
+  const saldoTag  = c.saldoInicial != null && c.dataReferenciaSaldo
+    ? `<span class="cat-desc" style="font-size:.78rem;color:var(--text-muted);">Saldo ref: R$ ${escHTML(Number(c.saldoInicial).toFixed(2).replace('.', ','))} em ${escHTML(c.dataReferenciaSaldo)}</span>`
+    : '';
   return `<div class="cat-item" style="border-left:4px solid ${escHTML(c.cor ?? '#546E7A')};opacity:${c._legado ? '.6' : '1'};">
     <div class="cat-item-main">
       <span class="cat-emoji">${escHTML(c.emoji)}</span>
       <div class="cat-info">
         <span class="cat-nome">${escHTML(c.nome)}${legadoTag}</span>
         <span class="cat-desc" style="font-size:.82rem;color:var(--text-muted);">${escHTML(c.tipo === 'dinheiro' ? 'Dinheiro' : 'Conta bancária')}</span>
+        ${saldoTag}
       </div>
+    </div>
+    <div class="cat-actions">
+      <button class="btn btn-outline btn-sm btn-editar-saldo" data-id="${escHTML(c.id)}">Saldo</button>
     </div>
   </div>`;
 }
 
 // ── Modal ─────────────────────────────────────────────────────
+
+// ── Modal de Saldo (RF-068) ───────────────────────────────────
+
+let _editandoSaldoId = null;
+
+function abrirModalSaldo(contaId) {
+  _editandoSaldoId = contaId;
+  const c = _contas.find(x => x.id === contaId);
+  if (!c) return;
+
+  document.getElementById('modal-saldo-titulo').textContent = `Saldo — ${c.nome}`;
+  document.getElementById('inp-saldo-inicial').value   = c.saldoInicial != null ? Number(c.saldoInicial) : '';
+  document.getElementById('inp-data-referencia').value = c.dataReferenciaSaldo ?? '';
+  document.getElementById('modal-saldo-banco').classList.remove('hidden');
+}
+
+function fecharModalSaldo() {
+  document.getElementById('modal-saldo-banco').classList.add('hidden');
+  _editandoSaldoId = null;
+}
+
+async function salvarSaldo(e) {
+  e.preventDefault();
+  if (!_editandoSaldoId) return;
+  // Verificar se a conta realmente pertence ao grupo atual (defense-in-depth)
+  if (!_contas.find(x => x.id === _editandoSaldoId)) return;
+
+  const saldoInicial        = parseFloat(document.getElementById('inp-saldo-inicial').value);
+  const dataReferenciaSaldo = document.getElementById('inp-data-referencia').value;
+
+  if (isNaN(saldoInicial) || !dataReferenciaSaldo) return;
+
+  try {
+    await atualizarConta(_editandoSaldoId, { saldoInicial, dataReferenciaSaldo });
+    fecharModalSaldo();
+  } catch (err) {
+    console.error('[contas] Erro ao salvar saldo:', err);
+    alert('Erro ao salvar saldo. Tente novamente.');
+  }
+}
+
+// ── Eventos ───────────────────────────────────────────────────
 
 function configurarEventos() {
   document.getElementById('btn-novo-cartao').addEventListener('click', () => abrirModalCartao(null));
@@ -173,6 +225,14 @@ function configurarEventos() {
   // Fechar modal ao clicar fora
   document.getElementById('modal-cartao').addEventListener('click', (e) => {
     if (e.target.id === 'modal-cartao') fecharModalCartao();
+  });
+
+  // RF-068: modal de saldo inicial
+  document.getElementById('btn-fechar-modal-saldo').addEventListener('click', fecharModalSaldo);
+  document.getElementById('btn-cancelar-saldo').addEventListener('click', fecharModalSaldo);
+  document.getElementById('form-saldo-banco').addEventListener('submit', salvarSaldo);
+  document.getElementById('modal-saldo-banco').addEventListener('click', (e) => {
+    if (e.target.id === 'modal-saldo-banco') fecharModalSaldo();
   });
 }
 

--- a/src/js/services/database.js
+++ b/src/js/services/database.js
@@ -271,6 +271,48 @@ export async function excluirConta(contaId) {
 }
 
 /**
+ * RF-068: Listener em tempo real de despesas do grupo desde uma data de referência.
+ * Usado para cálculo de saldo real por conta.
+ * @param {string} grupoId
+ * @param {Date}   dataReferencia — data mínima (inclusive)
+ * @param {Function} callback — recebe array de despesas
+ * @returns {Function} unsubscribe
+ */
+export function ouvirDespesasDesdeData(grupoId, dataReferencia, callback) {
+  const q = query(
+    collection(db, 'despesas'),
+    where('grupoId', '==', grupoId),
+    where('data', '>=', dataReferencia),
+    orderBy('data', 'desc'),
+  );
+  return onSnapshot(q,
+    (snap) => { callback(snap.docs.map((d) => ({ id: d.id, ...d.data() }))); },
+    (err)  => { console.error('[ouvirDespesasDesdeData] Erro no listener:', err); },
+  );
+}
+
+/**
+ * RF-068: Listener em tempo real de receitas do grupo desde uma data de referência.
+ * Usado para cálculo de saldo real por conta.
+ * @param {string} grupoId
+ * @param {Date}   dataReferencia — data mínima (inclusive)
+ * @param {Function} callback — recebe array de receitas
+ * @returns {Function} unsubscribe
+ */
+export function ouvirReceitasDesdeData(grupoId, dataReferencia, callback) {
+  const q = query(
+    collection(db, 'receitas'),
+    where('grupoId', '==', grupoId),
+    where('data', '>=', dataReferencia),
+    orderBy('data', 'desc'),
+  );
+  return onSnapshot(q,
+    (snap) => { callback(snap.docs.map((d) => ({ id: d.id, ...d.data() }))); },
+    (err)  => { console.error('[ouvirReceitasDesdeData] Erro no listener:', err); },
+  );
+}
+
+/**
  * Garante que todas as contas padrão existam para o grupo (upsert por nome).
  * Novos bancos adicionados ao CONTAS_PADRAO serão inseridos automaticamente
  * mesmo em grupos que já possuem contas.


### PR DESCRIPTION
## O que foi feito

- **model `Conta.js`**: adiciona campos `saldoInicial` (number, default 0) e `dataReferenciaSaldo` (string YYYY-MM-DD, default null) para contas banco/dinheiro
- **`database.js`**: novas funções `ouvirDespesasDesdeData` e `ouvirReceitasDesdeData` — listeners onSnapshot filtrados por `grupoId + data >= dataReferencia` (usa índices existentes)
- **`contas.html`**: modal "Configurar Saldo" com campos saldoInicial + dataReferenciaSaldo
- **`contas.js`**: botão "Saldo" em contas bancárias; modal `abrirModalSaldo/fecharModalSaldo/salvarSaldo`; guard de membership em salvarSaldo
- **`dashboard.html`**: card `#card-saldo-real` no Cockpit (visível quando ≥1 conta bancária configurada)
- **`app.js`**: `iniciarListenerSaldoReal` + `renderizarCardSaldoReal` — saldo consolidado + lista por conta; vermelho em saldo negativo; validação ISO_DATE_RE
- **`dashboard.css`**: `.resumo-card--saldo-real` + `.saldo-real-detalhes/.saldo-real-linha`

## Critérios de Aceite

- [x] CA1: Editar saldo inicial via Configurações > Contas
- [x] CA2: Adicionar despesa reduz saldo real da conta
- [x] CA3: Projeções e transferências internas NÃO afetam saldo real
- [x] CA4: Pagamento de fatura reduz saldo da conta origem
- [x] CA5: Card mostra saldo consolidado + lista por conta
- [x] CA6: Saldo negativo exibe indicador visual vermelho
- [x] CA7: Todas as queries usam `grupoId`

## Subagentes

- **test-runner**: PASS — 594/594 ✅ | build OK ✅
- **security-reviewer**: PASS — sem Critical/High; 2 achados menores corrigidos (guard membership + validação ISO_DATE_RE)
- **import-pipeline-reviewer**: N/A

## Como testar

1. `npm test` (594+ passando)
2. `npm run build`
3. Acesse Configurações > Contas, clique "Saldo" em qualquer conta bancária, informe saldo inicial e data de referência
4. Verifique card "Saldo Real" no Dashboard com saldo consolidado e breakdown por conta
5. Confirme indicador vermelho ao tornar saldo negativo

## Checklist

- [x] Sem credenciais Firebase no diff
- [x] CHANGELOG.md pendente (será atualizado no merge)
- [x] CSS usa variáveis de variables.css
- [x] chave_dedup intacta
- [x] grupoId presente em todas as queries Firestore
- [x] escHTML() em todo innerHTML com dados do usuário
- [x] onSnapshot: unsubscribe guardado para cleanup