### PR TITLE
fix(app): escHTML em renderizarPainelParcelamentos — prevenir XSS

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -582,13 +582,13 @@ function renderizarPainelParcelamentos(projecoes) {
   lista.innerHTML = Object.entries(porResp).map(([resp, d]) => `
     <div class="parc-resp-row">
       <div class="parc-resp-header">
-        <span class="parc-resp-nome">👤 ${resp}</span>
+        <span class="parc-resp-nome">👤 ${escHTML(resp)}</span>
         <span class="parc-resp-total">${formatarMoedaDash(d.total)}</span>
       </div>
       <div class="parc-resp-items">
         ${Object.values(d.compras).map(c => `
           <div class="parc-compra-item">
-            <span class="parc-compra-desc">${c.descricao}</span>
+            <span class="parc-compra-desc">${escHTML(c.descricao)}</span>
             <span class="parc-compra-info">${c.qtd} parcela${c.qtd > 1 ? 's' : ''} restante${c.qtd > 1 ? 's' : ''}</span>
             <span class="parc-compra-valor">${formatarMoedaDash(c.valor * c.qtd)}</span>
           </div>`).join('')}


### PR DESCRIPTION
## O que foi feito

Aplica `escHTML()` em `renderizarPainelParcelamentos` (`app.js`) nas strings `p.responsavel`, `p.portador` e `p.descricao` que eram inseridas diretamente via `innerHTML` sem sanitização.

Detectado pelo security-reviewer durante revisão do PR RF-068. Risco: XSS via dados maliciosos importados pelo pipeline de cartão/banco.

## Subagentes

- **security-reviewer**: achado identificado durante RF-068 review (Medium — escHTML ausente)
- **test-runner**: PASS — 594/594 ✅ (verificado na branch feat/MF-169 que inclui este patch)

## Checklist

- [x] escHTML() em todo innerHTML com dados do usuário
- [x] Sem outros impactos funcionais
- [x] 2 linhas alteradas em app.js