### PR TITLE
fix(fatura): escHTML em d.parcela e _catMap.nome no innerHTML (XSS)

### DIFF
--- a/src/js/pages/fatura.js
+++ b/src/js/pages/fatura.js
@@ -326,8 +326,8 @@ function renderizarTabela(tipo) {
         <td>${formatarData(d.data?.toDate?.() ?? d.data)}</td>
         <td class="fat-td-estab">${escHTML(d.descricao ?? '—')}</td>
         <td><span class="fat-badge fat-badge--${d.parcela && d.parcela !== '-' ? 'parc' : 'vista'}">${d.parcela && d.parcela !== '-' ? 'P' : 'V'}</span></td>
-        <td>${d.parcela && d.parcela !== '-' ? d.parcela : '—'}</td>
-        <td>${_catMap[d.categoriaId]?.nome ?? '—'}</td>
+        <td>${d.parcela && d.parcela !== '-' ? escHTML(d.parcela) : '—'}</td>
+        <td>${escHTML(_catMap[d.categoriaId]?.nome ?? '—')}</td>
         <td class="fat-td-valor">${formatarMoeda(d.valor)}</td>
         <td class="fat-td-valor fat-td-split">${formatarMoeda(d.valorAlocado ?? (d.valor ?? 0) / 2)}</td>
       </tr>`).join('') || '<tr><td colspan="7" class="fat-td-empty">Nenhuma despesa conjunta</td></tr>';
@@ -354,8 +354,8 @@ function renderizarTabela(tipo) {
       <td>${formatarData(d.data?.toDate?.() ?? d.data)}</td>
       <td class="fat-td-estab">${escHTML(d.descricao ?? '—')}</td>
       <td><span class="fat-badge fat-badge--${d.parcela && d.parcela !== '-' ? 'parc' : 'vista'}">${d.parcela && d.parcela !== '-' ? 'P' : 'V'}</span></td>
-      <td>${d.parcela && d.parcela !== '-' ? d.parcela : '—'}</td>
-      <td>${_catMap[d.categoriaId]?.nome ?? '—'}</td>
+      <td>${d.parcela && d.parcela !== '-' ? escHTML(d.parcela) : '—'}</td>
+      <td>${escHTML(_catMap[d.categoriaId]?.nome ?? '—')}</td>
       <td class="fat-td-valor">${formatarMoeda(d.valor)}</td>
     </tr>`).join('') || '<tr><td colspan="6" class="fat-td-empty">Nenhuma despesa individual</td></tr>';
 }
@@ -370,8 +370,8 @@ function _rowTodas(d) {
     <td class="fat-td-estab">${escHTML(d.descricao ?? '—')}</td>
     <td><span class="fat-resp-chip">${escHTML(resp.split(' ')[0])}</span></td>
     <td><span class="fat-badge fat-badge--${tipo === 'P' ? 'parc' : 'vista'}">${tipo}</span></td>
-    <td>${d.parcela && d.parcela !== '-' ? d.parcela : '—'}</td>
-    <td>${_catMap[d.categoriaId]?.nome ?? '—'}</td>
+    <td>${d.parcela && d.parcela !== '-' ? escHTML(d.parcela) : '—'}</td>
+    <td>${escHTML(_catMap[d.categoriaId]?.nome ?? '—')}</td>
     <td class="fat-td-valor">${formatarMoeda(d.valor)}</td>
     <td class="fat-td-valor ${isConj ? 'fat-td-split' : ''}">${formatarMoeda(mesBol)}</td>
   </tr>`;


### PR DESCRIPTION
## Summary

- `d.parcela` e `_catMap[d.categoriaId].nome` eram inseridos via `innerHTML` sem `escHTML()` em 3 funções: `renderizarTabela` (tabs conjuntas e por membro) e `_rowTodas` (tab Todas)
- 6 pontos de injeção corrigidos adicionando `escHTML()` em todos
- Vulnerabilidades **pré-existentes** ao PR #180 — identificadas pelo security-reviewer durante a sessão de NRF-NAV Fase 1

## Campos afetados

| Campo | Fonte | Contexto |
|-------|-------|---------|
| `d.parcela` | Firestore / import | `<td>` nas tabs Todas, Conjuntas, por-membro |
| `_catMap[...].nome` | Firestore (categorias) | `<td>` nas tabs Todas, Conjuntas, por-membro |

## Não alterado

- Linhas 534/535 e 569/570 usam os mesmos campos em `exportarExcel` via `XLSX.utils.aoa_to_sheet` (dados de planilha, não HTML — sem risco XSS)

## Test plan

- [x] 665 testes unitários passando (`npm test`)
- [x] Build limpo (sem erros de sintaxe)
- [x] `escHTML` já era importado no topo do arquivo — sem nova dependência

🤖 Generated with [Claude Code](https://claude.com/claude-code)