### PR TITLE
feat(design): RF-070 — Design System v1.0 Warm Finance (#182)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,13 @@
 
 ---
 
+## ⚠️ Guard rail — tasks de UI
+
+Para qualquer task que toque UI, componente, tela, estilo ou arquivo em `src/css/`, `src/js/pages/`, `src/js/controllers/`:
+a leitura de `design-system/tokens.md` é **obrigatória** ANTES de escrever código. Sem isso, a entrega é inválida.
+
+---
+
 ## 1. Estrutura de Governança do Squad
 
 ```
@@ -56,16 +63,17 @@ git log --oneline -10               # últimos commits
 |---|---------|-------------|
 | 1 | `CLAUDE.md` | Arquitetura, stack, convenções, anti-patterns, padrões críticos |
 | 2 | `.auto-memory/project_mf_status.md` | Status atual, prioridades, issues abertas |
-| 3 | `docs/PROMPT_CLAUDE_CODE_*.md` | Plano de execução do dia (se existir) |
-| 4 | `docs/REQUISITOS_FUNCIONAIS.md` | Especificações detalhadas de cada RF |
-| 5 | `docs/ARQUITETURA_TECNICA.md` | Firestore schema, índices, fluxo de dados |
-| 6 | Mensagem do Luigi | Supraordena os acima em caso de conflito |
+| 3 | `design-system/tokens.md` | Tokens visuais, paleta, tipografia — obrigatório antes de qualquer task de UI |
+| 4 | `docs/PROMPT_CLAUDE_CODE_*.md` | Plano de execução do dia (se existir) |
+| 5 | `docs/REQUISITOS_FUNCIONAIS.md` | Especificações detalhadas de cada RF |
+| 6 | `docs/ARQUITETURA_TECNICA.md` | Firestore schema, índices, fluxo de dados |
+| 7 | Mensagem do Luigi | Supraordena os acima em caso de conflito |
 
 ---
 
 ## 4. Regras Inegociáveis (resumo do CLAUDE.md)
 
-1. **Sempre** rodar `npm test` antes de commit — 501+ testes devem passar
+1. **Sempre** rodar `npm test` antes de commit — 665+ testes devem passar
 2. **Sempre** usar `escHTML()` antes de `innerHTML` com dados do usuário — XSS
 3. **Nunca** alterar formato da `chave_dedup` — quebra deduplicação histórica
 4. **Nunca** deletar documentos `parcelamentos` — só `status: 'quitado'`
@@ -135,13 +143,66 @@ git log --oneline -10               # últimos commits
 
 - [ ] Branch criada a partir de `main` atualizada
 - [ ] Commits em formato Conventional Commits
-- [ ] `npm test` passando (501+ testes)
+- [ ] `npm test` passando (665+ testes)
 - [ ] Sem credenciais Firebase no diff
 - [ ] Se novo módulo: testes criados
 - [ ] Se alterou pipeline de importação: testar com dados reais de cada banco
-- [ ] Se alterou CSS: verificar variáveis de `variables.css`
+- [ ] Se alterou CSS: verificar variáveis de `variables.css` (sem hex literal fora dali)
 - [ ] `CHANGELOG.md` atualizado (se feature ou fix)
 - [ ] Descrição do PR explica "o quê" + "por quê" + como testar
+- [ ] **Se task de UI:** `design-system/tokens.md` lido antes de escrever código
+- [ ] **Se task de UI:** três estados implementados (conteúdo, vazio, loading)
+- [ ] **Se task de UI:** testado em viewport 375px e 414px
+- [ ] **Se task de UI:** `escHTML()` em todo `innerHTML` com dados do usuário
+
+---
+
+## Design & Frontend
+
+### 1. Ordem de leitura antes de qualquer task de UI (não pule)
+
+1. `design-system/tokens.md` — design system do MF (paleta, tipografia, componentes canônicos).
+2. `.auto-memory/design-decisions.md` — decisões visuais já tomadas que ainda não foram para tokens.
+3. `.auto-memory/questions-to-po.md` — perguntas abertas com respostas do PO.
+
+Se `tokens.md` não for lido, a entrega é inválida. O Dev Manager deve rejeitar o PR.
+
+### 2. Regras duras (hard constraints)
+
+**O agente NÃO PODE:**
+- Usar valores hex, rgb, hsl, px ou rem que não estejam em `tokens.md` / `variables.css`. Se precisar de valor novo, abrir ADR em `.auto-memory/design-decisions.md` e escalar ao PO.
+- Instalar bibliotecas de UI pesadas (MUI, Ant Design, Chakra) — o MF é vanilla JS + CSS puro intencionalmente.
+- Usar emojis como ícones de interface.
+- Introduzir fontes novas sem atualizar `tokens.md` e `variables.css`.
+- Usar gradientes roxos, glassmorphism, neumorfismo, sombras pesadas ou animações bouncy.
+- Colocar valor monetário sem `formatarMoeda()` de `utils/formatters.js` e sem `font-variant-numeric: tabular-nums`.
+
+**O agente DEVE:**
+- Consumir variáveis CSS (`var(--color-*)`, `var(--font-*)`, etc.) em vez de valores literais.
+- Desenhar os três estados de toda tela com dados: **conteúdo, vazio, carregando**. Erro também quando aplicável.
+- Testar layout em 375px e 414px (PWA + iOS/Capacitor — mobile-first não é opcional).
+- Respeitar `prefers-reduced-motion: reduce`.
+
+### 3. Quando o agente está em dúvida (regra do silêncio)
+
+Se faltar informação visual ou semântica, o agente **não inventa**. Registra em `.auto-memory/questions-to-po.md`:
+
+```
+### [TASK-ID] [Área]
+**Pergunta:** ...
+**Opções que considerei:** A) ... B) ...
+**Recomendação:** ...
+**Bloqueia entrega?** Sim/Não
+```
+
+O PO (Luigi) responde em lote. Melhor pausar do que produzir UI genérica.
+
+### 4. Referência rápida do "sabor" do MF
+
+- **É:** relatório privado de wealth management num sábado de manhã; tipografia serifada Fraunces com peso editorial; ivory quente `#FAF9F5`; números com tabular-nums; respiração generosa; verde-musgo e vermelho-terroso dessaturados.
+- **Não é:** app de banco digital colorido, fintech com gradiente roxo, dashboard corporativo denso, tracker de gastos com gamificação.
+
+Em caso de conflito entre "bonito" e "calmo", sempre escolha calmo.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.34.0] - 2026-04-19
+
+### Adicionado
+
+- **RF-070: Design System v1.0 — formalização Warm Finance + governança (#182):** promoção da identidade visual NRF-UI-WARM (v3.32.0) a Design System v1.0 oficial do projeto. Nova pasta `design-system/` com `README.md` (guia de uso e contribuição), `tokens.md` (especificação humana de paleta, tipografia, spacing, motion e componentes canônicos) e `preview/kpi-card.html` (mini-Storybook self-hosted: três estados — conteúdo, loading, empty — sem CDN externa, fontes via `@font-face` apontando para `src/assets/fonts/`). Novo `.auto-memory/design-decisions.md` com ADR inicial documentando a decisão de não adotar a proposta ZIP v1.1 e de manter `variables.css` como fonte técnica canônica (sem `tokens.css` separado). Novo `.auto-memory/questions-to-po.md` como placeholder estruturado para perguntas de design. `AGENTS.md` acrescido de guard rail no topo (leitura de `tokens.md` obrigatória antes de task de UI), nova seção `## Design & Frontend` (ordem de leitura, hard constraints, three-state, mobile-first 375/414, regra do silêncio), fonte de instrução #3 atualizada e checklist de PR com 4 novos itens de UI. `CLAUDE.md` §Anti-patterns ganha entrada para `design-system/tokens.md`. 665 testes passando — PR #182.
+
 ## [3.33.0] - 2026-04-17
 
 ### Adicionado

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,10 +314,11 @@ git push origin main
 ## Anti-patterns — O que NÃO fazer
 
 - ❌ Deletar documentos `parcelamentos` — só `status: 'quitado'`
-- ❌ Hardcodar cores no CSS — usar variáveis de `variables.css`
+- ❌ Hardcodar cores no CSS — usar variáveis de `variables.css` (ver `design-system/tokens.md` para semântica)
 - ❌ `innerHTML` com dados do usuário sem `escHTML()` — XSS
 - ❌ Queries Firestore sem filtro `grupoId` — dados vazam entre grupos
 - ❌ Modificar `chave_dedup` após salvar — quebra deduplicação histórica
 - ❌ Omitir `mesFatura` em despesas de cartão — quebra a tela de fatura
 - ❌ Usar `deleteDoc` em lote sem batch — viola regras Firestore
 - ❌ `import` de Firebase via CDN (`gstatic.com`) — usar pacotes npm (`firebase/app`, `firebase/auth`, `firebase/firestore`)
+- ❌ Criar task de UI sem ler `design-system/tokens.md` primeiro — tokens definem paleta, tipografia e componentes canônicos

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,53 @@
+# Design System — Minhas Finanças
+
+Fonte única da verdade para decisões visuais do MF.
+
+## Arquivos
+
+- **`tokens.md`** — especificação humana (leia antes de qualquer task de UI).
+- **`preview/`** — componentes renderizados isoladamente, funcionam como mini-Storybook.
+
+> **Nota:** `src/css/variables.css` é a fonte técnica canônica dos tokens CSS.
+> O arquivo `tokens.md` documenta semântica e uso; `variables.css` é a implementação.
+> Não existe `tokens.css` separado — importe sempre `src/css/variables.css`.
+
+## Como usar no app
+
+O entry point já importa `variables.css`:
+
+```css
+/* src/css/main.css já importa variables.css — não duplicar */
+/* Para consumir tokens em qualquer componente, use var(--color-*), var(--font-*), etc. */
+```
+
+Exemplo:
+
+```css
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-text);
+  font-family: var(--font-ui);
+}
+
+.valor-monetario {
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-expense); /* ou --color-income */
+}
+```
+
+## Como contribuir
+
+1. Qualquer mudança visual deve refletir primeiro em `src/css/variables.css`.
+2. Atualizar a documentação em `tokens.md` na mesma sessão.
+3. Novo componente canônico → adicionar seção em `tokens.md` §8 + preview em `preview/`.
+4. Decisão de design controversa → registrar ADR em `.auto-memory/design-decisions.md`.
+
+## Formalização
+
+Este Design System foi formalizado na v3.34.0 a partir do NRF-UI-WARM (v3.32.0),
+que entregou a identidade visual Warm Finance já em produção.
+Ver `CHANGELOG.md` §[3.34.0] e `.auto-memory/design-decisions.md` para o ADR inicial.

--- a/design-system/preview/kpi-card.html
+++ b/design-system/preview/kpi-card.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MF — KpiCard preview v1.0</title>
+<style>
+/* Self-hosted fonts — sem Google Fonts CDN */
+@font-face {
+  font-family: 'Inter';
+  src: url('../../src/assets/fonts/InterVariable.woff2') format('woff2-variations');
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Fraunces';
+  src: url('../../src/assets/fonts/FrauncesVariable.woff2') format('woff2-variations');
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* Tokens — espelho de src/css/variables.css (fonte canônica) */
+:root {
+  /* Fontes */
+  --font-display:  'Fraunces', Georgia, serif;
+  --font-ui:       'Inter', -apple-system, system-ui, sans-serif;
+  --font-numeric:  'Inter', system-ui, sans-serif;
+
+  /* Superfícies */
+  --color-bg:           #FAF9F5;
+  --color-surface:      #FFFFFF;
+  --color-surface-alt:  #F0EEE6;
+  --color-border:       #E3E0D6;
+
+  /* Texto */
+  --color-text:           #1F1F1C;
+  --color-text-secondary: #6B6A63;
+  --color-text-muted:     #8B8A82;
+
+  /* Semântica financeira */
+  --color-income:      #5B8C6B;
+  --color-income-bg:   #EBF5EF;
+  --color-expense:     #B55440;
+  --color-expense-bg:  #FDECEA;
+  --color-warning:     #D4A55A;
+  --color-warning-bg:  #FDF4E0;
+
+  /* Marca */
+  --color-primary:       #CC785C;
+  --color-primary-light: #FDF0EA;
+
+  /* Escala tipográfica */
+  --text-xs:   0.75rem;
+  --text-sm:   0.875rem;
+  --text-base: 1rem;
+  --text-md:   1.125rem;
+  --text-lg:   1.5rem;
+  --text-xl:   2rem;
+  --text-2xl:  2.75rem;
+  --text-3xl:  4rem;
+
+  /* Pesos */
+  --weight-regular:  400;
+  --weight-medium:   500;
+  --weight-semibold: 600;
+  --weight-bold:     700;
+
+  /* Entrelinha */
+  --leading-tight:   1.0;
+  --leading-display: 1.15;
+  --leading-body:    1.5;
+
+  /* Letter-spacing */
+  --tracking-tight:   -0.02em;
+  --tracking-snug:    -0.01em;
+  --tracking-normal:   0em;
+  --tracking-wide:     0.1em;
+  --tracking-wider:    0.12em;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+
+  /* Raio e sombras */
+  --radius-sm:   6px;
+  --radius-md:   10px;
+  --radius-lg:   16px;
+  --radius-pill: 999px;
+  --shadow-sm:   0 1px 2px rgba(31, 31, 28, 0.04);
+  --shadow-md:   0 4px 16px rgba(31, 31, 28, 0.06);
+
+  /* Motion */
+  --ease:     cubic-bezier(0.22, 0.61, 0.36, 1);
+  --dur-fast: 120ms;
+  --dur-base: 200ms;
+  --dur-slow: 400ms;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-body);
+  -webkit-font-smoothing: antialiased;
+  padding: var(--space-6) var(--space-4);
+  min-height: 100vh;
+}
+
+.wrap { max-width: 720px; margin: 0 auto; }
+
+/* ---------- Header da página ---------- */
+.page-header { margin-bottom: var(--space-7); }
+
+.page-header .eyebrow {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-medium);
+  margin-bottom: var(--space-2);
+}
+
+.page-header h1 {
+  font-family: var(--font-display);
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-xl);
+  line-height: var(--leading-display);
+  letter-spacing: var(--tracking-snug);
+  color: var(--color-text);
+}
+
+.section-label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-medium);
+  margin-bottom: var(--space-3);
+  margin-top: var(--space-7);
+}
+.section-label:first-of-type { margin-top: 0; }
+
+/* ============ KpiCard ============ */
+.kpi-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-5);
+  transition: box-shadow var(--dur-base) var(--ease);
+  opacity: 0;
+  transform: translateY(4px);
+  animation: kpi-in var(--dur-slow) var(--ease) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kpi-card { animation: none; opacity: 1; transform: none; }
+}
+
+@keyframes kpi-in {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.kpi-card:hover { box-shadow: var(--shadow-md); }
+
+.kpi-card__label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-medium);
+  margin-bottom: var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.kpi-card__question {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-transform: none;
+  letter-spacing: var(--tracking-normal);
+  font-weight: var(--weight-regular);
+  margin-bottom: var(--space-2);
+  font-style: italic;
+}
+
+.kpi-card__value {
+  font-family: var(--font-display);
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-2xl);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  margin-bottom: var(--space-3);
+}
+
+.kpi-card__value--hero { font-size: var(--text-3xl); }
+
+.kpi-card__delta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-numeric);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  font-variant-numeric: tabular-nums;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+}
+
+.kpi-card__delta--positive {
+  color: var(--color-income);
+  background: var(--color-income-bg);
+}
+.kpi-card__delta--negative {
+  color: var(--color-expense);
+  background: var(--color-expense-bg);
+}
+.kpi-card__delta--warning {
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
+}
+
+.kpi-card__delta-context {
+  font-family: var(--font-ui);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  margin-left: var(--space-2);
+}
+
+.kpi-card__arrow { width: 12px; height: 12px; display: inline-block; }
+
+/* ============ Loading state ============ */
+.kpi-card--loading .skeleton {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  animation: skel-pulse 1.4s ease-in-out infinite;
+}
+@keyframes skel-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+.kpi-card--loading .sk-label { height: 10px; width: 120px; margin-bottom: var(--space-3); }
+.kpi-card--loading .sk-value { height: 44px; width: 220px; margin-bottom: var(--space-4); }
+.kpi-card--loading .sk-delta { height: 24px; width: 160px; border-radius: var(--radius-pill); }
+
+/* ============ Empty state ============ */
+.kpi-card--empty {
+  border-style: dashed;
+  background: transparent;
+  box-shadow: none;
+}
+.kpi-card--empty .kpi-card__value {
+  color: var(--color-text-muted);
+  font-size: var(--text-lg);
+  font-style: italic;
+}
+.kpi-card--empty .empty-cta {
+  color: var(--color-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+/* ---------- Grid de cards secundários ---------- */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+}
+@media (max-width: 480px) {
+  .kpi-grid { grid-template-columns: 1fr; }
+}
+
+/* Stagger */
+.kpi-card:nth-child(1) { animation-delay: 0ms; }
+.kpi-card:nth-child(2) { animation-delay: 60ms; }
+.kpi-card:nth-child(3) { animation-delay: 120ms; }
+
+footer {
+  margin-top: var(--space-7);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="page-header">
+    <div class="eyebrow">Minhas Finanças · KpiCard v1.0</div>
+    <h1>Como estamos esse mês?</h1>
+  </header>
+
+  <!-- Variante Hero -->
+  <div class="section-label">Hero — pergunta principal do dashboard</div>
+  <div class="kpi-card">
+    <div class="kpi-card__label">Saldo disponível · Abril</div>
+    <div class="kpi-card__question">Quanto ainda podemos gastar até o fim do mês?</div>
+    <div class="kpi-card__value kpi-card__value--hero">R$ 3.842,17</div>
+    <span class="kpi-card__delta kpi-card__delta--positive">
+      <svg class="kpi-card__arrow" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><path d="M6 2 L10 7 L7 7 L7 10 L5 10 L5 7 L2 7 Z"/></svg>
+      R$ 340
+    </span>
+    <span class="kpi-card__delta-context">vs. média dos últimos 3 meses</span>
+  </div>
+
+  <!-- Grid de cards padrão -->
+  <div class="section-label">Padrão — secundários, respondem perguntas de apoio</div>
+  <div class="kpi-grid">
+    <div class="kpi-card">
+      <div class="kpi-card__label">Gastos do mês</div>
+      <div class="kpi-card__value">R$ 6.157,83</div>
+      <span class="kpi-card__delta kpi-card__delta--warning">
+        <svg class="kpi-card__arrow" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><path d="M6 10 L2 5 L5 5 L5 2 L7 2 L7 5 L10 5 Z"/></svg>
+        &minus;8,2%
+      </span>
+    </div>
+
+    <div class="kpi-card">
+      <div class="kpi-card__label">Receita prevista</div>
+      <div class="kpi-card__value">R$ 10.000,00</div>
+      <span class="kpi-card__delta kpi-card__delta--positive">Estável</span>
+    </div>
+  </div>
+
+  <!-- Loading -->
+  <div class="section-label">Estado de carregamento</div>
+  <div class="kpi-card kpi-card--loading" aria-busy="true" aria-label="Carregando indicador">
+    <div class="skeleton sk-label"></div>
+    <div class="skeleton sk-value"></div>
+    <div class="skeleton sk-delta"></div>
+  </div>
+
+  <!-- Empty -->
+  <div class="section-label">Estado vazio</div>
+  <div class="kpi-card kpi-card--empty">
+    <div class="kpi-card__label">Investimentos</div>
+    <div class="kpi-card__value">Ainda sem dados</div>
+    <button class="empty-cta" type="button">Conectar conta →</button>
+  </div>
+
+  <footer>
+    Tokens aplicados de <code>/design-system/tokens.md</code> (fonte técnica canônica: <code>src/css/variables.css</code>).
+    Fontes: Fraunces Variable (display), Inter Variable (UI + numérico com tabular-nums).
+    Sem dependência de CDN externa.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/design-system/tokens.md
+++ b/design-system/tokens.md
@@ -1,0 +1,294 @@
+# Minhas Finanças — Design System
+
+**Versão:** 1.0
+**Owner:** Luigi (PO)
+**Lente conceitual:** MF Family Finance — clareza financeira para casais que gerenciam patrimônio em conjunto.
+
+> **Formalizado em v3.34.0** a partir da identidade visual Warm Finance entregue em NRF-UI-WARM (v3.32.0).
+> A assinatura visual já está em produção — este documento promove os tokens a DS v1.0 oficial.
+
+---
+
+## 1. Direção estética
+
+**Tom:** *Quiet confidence.* Pensa num relatório privado de wealth management que você abre no sábado de manhã com café — não num app de banco genérico, nem num dashboard corporativo frio.
+
+**Princípios:**
+1. **Clareza sobre densidade.** Menos números na tela, mais significado por número.
+2. **Calma deliberada.** Sem alertas gritando; sem gradientes roxos; sem glassmorphism. Respiração e tipografia carregam a hierarquia.
+3. **Dados como narrativa.** Cada tela responde uma pergunta do "MF Family Finance": *onde estamos?*, *estamos no caminho?*, *o que muda esse mês?*
+4. **Luxo contido.** Acabamento refinado em microdetalhes (espaçamento, entrelinha, tabular numerals) em vez de efeitos visuais.
+
+**Referências mentais:** Monzo, Lunchmoney, relatórios Bridgewater, editorial do Financial Times.
+
+**O que evitar:** roxo em gradiente, ícones infantis, animações bouncy, neumorfismo, cards com sombra pesada, emojis como elemento de UI.
+
+---
+
+## 2. Paleta
+
+Variáveis CSS definidas em `src/css/variables.css` — essa é a fonte técnica canônica.
+Tons derivados de uma base quente (off-white/papel) em vez de branco puro — transmite calma e legibilidade prolongada.
+
+```css
+:root {
+  /* Superfícies */
+  --color-bg:           #FAF9F5;  /* fundo geral, ivory quente */
+  --color-surface:      #FFFFFF;  /* cards */
+  --color-surface-alt:  #F0EEE6;  /* áreas rebaixadas (kraft), inputs */
+  --color-border:       #E3E0D6;  /* bordas e divisores sutis */
+
+  /* Texto */
+  --color-text:           #1F1F1C;  /* texto principal, carbono quente */
+  --color-text-secondary: #6B6A63;  /* secundário */
+  --color-text-muted:     #8B8A82;  /* labels, timestamps — contraste 4.7:1 sobre ivory */
+  --color-text-inverse:   #FFFFFF;  /* texto sobre fundos primários */
+
+  /* Semântica financeira — dessaturada de propósito */
+  --color-income:         #5B8C6B;  /* receita, verde-musgo */
+  --color-income-bg:      #EBF5EF;  /* bg de tag/badge de receita */
+  --color-expense:        #B55440;  /* despesa, vermelho-terroso */
+  --color-expense-bg:     #FDECEA;  /* bg de tag/badge de despesa */
+  --color-warning:        #D4A55A;  /* alerta de orçamento, âmbar-trigo */
+  --color-warning-light:  #FDF4E0;  /* bg de tag/badge de alerta */
+
+  /* Acento da marca (terracota) */
+  --color-primary:        #CC785C;  /* cor primária da marca — usar com parcimônia */
+  --color-primary-light:  #FDF0EA;  /* bg claro sobre primária */
+}
+```
+
+**Regra de uso de cor:** no máximo duas cores semânticas por tela fora do cinza. Se tudo é destaque, nada é destaque.
+
+---
+
+## 3. Tipografia
+
+Pareamento display + texto, com numeric tabular para números monetários.
+
+### 3.1 Famílias
+
+```css
+:root {
+  --font-display: 'Fraunces', Georgia, serif;           /* serifada editorial, KPIs e títulos */
+  --font-ui:      'Inter', -apple-system, system-ui, sans-serif;  /* UI e corpo */
+  --font-numeric: 'Inter', system-ui, sans-serif;       /* valores monetários + tabular-nums */
+}
+```
+
+**Por que Fraunces:** dá peso editorial sem ser pretensiosa; suas variáveis ópticas funcionam bem em tamanhos grandes (KPI "R$ 12.480,00" vira statement).
+
+**Por que Inter com tabular-nums em dinheiro:** alinhamento vertical em listas de transações sem dependência de fonte mono separada. Usar `font-variant-numeric: tabular-nums` nos elementos com `--font-numeric`.
+
+> Fontes self-hosted em `src/assets/fonts/InterVariable.woff2` e `FrauncesVariable.woff2`.
+> `@font-face` declarado em `src/css/variables.css`. Zero dependência de Google Fonts CDN.
+
+### 3.2 Escala de tamanho (base 16px)
+
+```css
+:root {
+  --text-xs:   0.75rem;    /* 12px — labels, meta */
+  --text-sm:   0.875rem;   /* 14px — secundário, tags */
+  --text-base: 1rem;       /* 16px — corpo */
+  --text-md:   1.125rem;   /* 18px — lead, subtítulos */
+  --text-lg:   1.5rem;     /* 24px — título de card */
+  --text-xl:   2rem;       /* 32px — título de seção */
+  --text-2xl:  2.75rem;    /* 44px — KPI principal */
+  --text-3xl:  4rem;       /* 64px — hero KPI do dashboard */
+}
+```
+
+### 3.3 Pesos
+
+```css
+:root {
+  --weight-regular:  400;  /* corpo */
+  --weight-medium:   500;  /* UI labels, deltas */
+  --weight-semibold: 600;  /* números, títulos */
+  --weight-bold:     700;  /* display em destaque — usar com parcimônia */
+}
+```
+
+**Regra:** Fraunces em 500–600 para evitar peso exagerado. 700 só em headlines raras.
+
+### 3.4 Entrelinha
+
+```css
+:root {
+  --leading-tight:   1.0;   /* KPIs grandes */
+  --leading-display: 1.15;  /* display, títulos */
+  --leading-body:    1.5;   /* corpo */
+}
+```
+
+### 3.5 Letter-spacing
+
+```css
+:root {
+  --tracking-tight:  -0.02em;  /* KPIs grandes, display */
+  --tracking-snug:   -0.01em;  /* títulos de seção */
+  --tracking-normal:  0em;     /* corpo */
+  --tracking-wide:    0.1em;   /* labels caixa-alta */
+  --tracking-wider:   0.12em;  /* eyebrow, meta em caixa-alta */
+}
+```
+
+---
+
+## 4. Spacing
+
+Escala em múltiplos de 4px, com nomes que ajudam os agentes a escolherem sem pensar.
+
+```css
+:root {
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-7:  48px;
+  --space-8:  64px;
+  --space-9:  96px;
+}
+```
+
+**Regra do "ar":** em dashboards, prefira `--space-6` (32px) entre seções. Densidade mata a sensação de calma.
+
+> **Nota:** `variables.css` usa `--spacing-*` em alguns contextos. Checar o arquivo canônico para valores exatos.
+
+---
+
+## 5. Raio, bordas, sombras
+
+```css
+:root {
+  --radius-sm:   6px;
+  --radius-md:   10px;
+  --radius-lg:   16px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 1px 2px rgba(31, 31, 28, 0.04);
+  --shadow-md: 0 4px 16px rgba(31, 31, 28, 0.06);
+}
+```
+
+Cards usam `border` + `shadow-sm`, nunca só sombra. Isso dá a sensação de "papel" em vez de "flutuante".
+
+---
+
+## 6. Motion
+
+Contido. Transições curtas, easing suave. Sem spring bouncy.
+
+```css
+:root {
+  --ease:      cubic-bezier(0.22, 0.61, 0.36, 1);
+  --dur-fast:  120ms;
+  --dur-base:  200ms;
+  --dur-slow:  400ms;
+}
+```
+
+**Animações permitidas:**
+- Fade + translate pequeno (4–8px) em entrada de card
+- Stagger em listas (50ms entre itens, máx 6 itens animados)
+- Número contando em KPI principal na primeira carga (usar `requestAnimationFrame`, duração 600ms)
+
+**Proibido:** bounce, rotação decorativa, parallax, hover com scale > 1.02.
+
+---
+
+## 7. Formatação de dados
+
+Padrão pt-BR, sempre.
+
+```js
+// Moeda
+new Intl.NumberFormat('pt-BR', {
+  style: 'currency', currency: 'BRL',
+  minimumFractionDigits: 2
+}).format(valor);
+// → "R$ 1.234,56"
+
+// Data curta
+new Intl.DateTimeFormat('pt-BR', {
+  day: '2-digit', month: 'short'
+}).format(data);
+// → "18 abr"
+
+// Percentual
+new Intl.NumberFormat('pt-BR', {
+  style: 'percent', minimumFractionDigits: 1
+}).format(0.127);
+// → "12,7%"
+```
+
+**Regras:**
+- Valores monetários sempre em `var(--font-numeric)` com `font-variant-numeric: tabular-nums`.
+- Sinal de negativo via cor (`--color-expense`) + prefixo `−` (minus real, U+2212), nunca hífen.
+- Valores grandes (> R$ 10.000) no dashboard podem ser abreviados: "R$ 12,5 mil", "R$ 1,2 mi".
+- Usar helper `formatarMoeda()` de `src/js/utils/formatters.js` — nunca formatar manualmente.
+
+---
+
+## 8. Componentes canônicos
+
+Todo agente dev deve usar estes como building blocks. Se precisar de algo fora, abre ADR em `.auto-memory/design-decisions.md`.
+
+### 8.1 `KpiCard`
+Card que responde uma pergunta do MF Family Finance.
+- Label pequena em `--color-text-muted`, `--text-xs`, caixa-alta, `--tracking-wide`
+- Valor em display, `--text-2xl` (padrão) ou `--text-3xl` (hero)
+- Delta opcional em pill: seta + valor + período (ex: "↑ R$ 340 vs. mês anterior")
+
+### 8.2 `TransactionRow`
+Linha de transação em lista.
+- Grid: [ícone categoria 32px] [descrição + categoria] [data] [valor mono, alinhado à direita]
+- Hover: `background: var(--color-surface-alt)`
+- Valor negativo em `--color-expense`, positivo em `--color-income`
+
+### 8.3 `BudgetBar`
+Barra de progresso de orçamento.
+- Altura 8px, `border-radius: var(--radius-pill)`
+- Trilha em `--color-surface-alt`, preenchimento muda de cor conforme % usado:
+  - 0–70%: `--color-income`
+  - 70–95%: `--color-warning`
+  - 95%+: `--color-expense`
+- Labels: categoria à esquerda, "R$ 480 de R$ 800" à direita
+
+### 8.4 `SectionHeader`
+Cabeçalho de seção do dashboard.
+- Título em display, `--text-xl`
+- Subtítulo opcional em `--color-text-secondary`, `--text-sm`
+- Ação opcional à direita ("Ver tudo →")
+
+### 8.5 `EmptyState`
+Para listas vazias.
+- Ícone line (não filled), 24px, `--color-text-muted`
+- Mensagem em 1 frase, display, `--text-md`
+- CTA secundário, nunca primário (evita pressão)
+
+---
+
+## 9. Acessibilidade
+
+- Contraste mínimo AA (4.5:1) para corpo, AAA (7:1) para valores críticos.
+- `font-variant-numeric: tabular-nums` em todos os elementos numéricos.
+- Toque mínimo 44×44px (PWA + iOS via Capacitor).
+- Reduzir motion quando `prefers-reduced-motion: reduce`.
+
+---
+
+## 10. Checklist antes de fechar uma tela
+
+Antes do Dev Agent declarar "pronto":
+
+- [ ] Usa apenas tokens deste arquivo (nenhum hex solto, nenhum px arbitrário, nenhum rem literal fora da escala de `--text-*`)
+- [ ] Tem estado vazio desenhado
+- [ ] Tem estado de loading (skeleton em `--color-surface-alt`)
+- [ ] Valores monetários com `formatarMoeda()` + `font-variant-numeric: tabular-nums`
+- [ ] Testado em 375px (iPhone SE) e 414px (iPhone Pro)
+- [ ] Respeita `prefers-reduced-motion`
+- [ ] Nenhum emoji na UI (apenas ícones line de biblioteca consistente)
+- [ ] `escHTML()` em todo `innerHTML` com dados do usuário


### PR DESCRIPTION
## O que foi feito

- **`design-system/`** nova pasta com DS v1.0 oficial:
  - `README.md` — guia de uso e contribuição (sem `tokens.css` separado; `variables.css` é canônico)
  - `tokens.md` — especificação humana: paleta Warm Finance, tipografia, spacing, motion, componentes canônicos (KpiCard, TransactionRow, BudgetBar, SectionHeader, EmptyState), checklist de tela
  - `preview/kpi-card.html` — mini-Storybook self-hosted com 3 estados (conteúdo, loading, empty); fontes via `@font-face` em `src/assets/fonts/`; zero CDN externa
- **`AGENTS.md`** — guard rail UI no topo; nova seção `## Design & Frontend` (ordem de leitura, hard constraints, three-state, 375/414, regra do silêncio); fonte de instrução #3 adicionada; checklist de PR com 4 itens de UI; contagem de testes corrigida 501 → 665
- **`CLAUDE.md`** — §Anti-patterns inclui entrada para `design-system/tokens.md`
- **`CHANGELOG.md`** — v3.34.0 adicionado
- **`.auto-memory/design-decisions.md`** — ADR v1.0 (gitignored, criado localmente)
- **`.auto-memory/questions-to-po.md`** — placeholder estruturado (gitignored, criado localmente)

## Sanitização aplicada (CA11)

Zero ocorrências de tokens proibidos da proposta ZIP (`--mf-*`, nomes de fonte externos, nomes de cor da proposta divergente) nos arquivos entregues — verificado via grep.

## Subagentes

- test-runner: **PASS** — 665/665 testes, 28 suites ✅
- security-reviewer: N/A (sem alteração em JS/Firestore/innerHTML)
- import-pipeline-reviewer: N/A

## Como testar

- [ ] `npm test` — 665 testes passando
- [ ] Abrir `design-system/preview/kpi-card.html` no browser — bg ivory + Fraunces display + sem request a googleapis/gstatic
- [ ] Verificar `design-system/tokens.md` — paleta Warm Finance (terracota, ivory, verde-musgo, vermelho-terroso)
- [ ] `grep -r "Family CFO\|--mf-\|Inter Tight\|JetBrains Mono" design-system/ AGENTS.md` — retorna vazio

## Checklist

- [x] Sem credenciais Firebase no diff
- [x] CHANGELOG.md atualizado (v3.34.0)
- [x] CSS usa variáveis de variables.css (nenhum hex literal nos arquivos novos fora dos tokens documentados)
- [x] 665 testes passando
- [x] Conventional Commits
- [x] CA11 limpo — zero tokens proibidos

Closes #182