### PR TITLE
feat(base-dados): ENH-002 — exibir rota em transferências internas + filtro (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.35.0] - 2026-04-19
+
+### Adicionado
+
+- **ENH-002: exibir origem e destino em transferências internas (#152):** linhas com `tipo=transferencia_interna` na Base de Dados agora exibem a rota da transferência como subtítulo na coluna Descrição (`portador → destino` para despesas; `origem → portador` para receitas), resolvida via `_nomesMembros` do grupo. Badge de tipo renomeado para "🔁 Transferência" com cor info (`ger-tipo-transf`). Novo filtro "🔁 Transferências Internas" no seletor de tipo da aba Gerenciar. Filtro de despesas atualizado para excluir transferências internas ao selecionar "💸 Despesas". Todos os valores inseridos via `escHTML()`. 665 testes passando.
+
 ## [3.34.0] - 2026-04-19
 
 ### Adicionado

--- a/src/base-dados.html
+++ b/src/base-dados.html
@@ -456,6 +456,7 @@
             <option value="despesa">💸 Despesas</option>
             <option value="receita">📥 Receitas</option>
             <option value="projecao">📆 Projeções</option>
+            <option value="transferencia_interna">🔁 Transferências Internas</option>
           </select>
           <select id="ger-fil-mes" class="select-input ger-fil-select">
             <option value="">Todos os meses</option>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1073,6 +1073,7 @@ a:hover { text-decoration: underline; }
 .ger-tipo-despesa  { background: var(--color-danger-light); color: var(--color-danger-text); }
 .ger-tipo-receita  { background: var(--color-ok-light); color: var(--color-ok-text); }
 .ger-tipo-projecao { background: var(--color-balance-bg); color: var(--color-balance-dark); }
+.ger-tipo-transf   { background: var(--color-info-light); color: var(--color-info-text); }
 
 /* ── Paginação ── */
 .ger-paginacao {

--- a/src/js/pages/base-dados.js
+++ b/src/js/pages/base-dados.js
@@ -368,7 +368,7 @@ function preencherSelResp() {
   if (!sel) return;
   const nomes = Object.values(_nomesMembros);
   sel.innerHTML = '<option value="">— selecione —</option>' +
-    nomes.map(n => `<option value="${n}">${n}</option>`).join('');
+    nomes.map(n => `<option value="${escHTML(n)}">${escHTML(n)}</option>`).join('');
 }
 
 function aplicarFiltros() {
@@ -380,9 +380,10 @@ function aplicarFiltros() {
 
   _filtradas = _todasTransacoes.filter(t => {
     if (tipo !== 'todos') {
-      if (tipo === 'projecao' && t.tipo !== 'projecao') return false;
+      if (tipo === 'transferencia_interna' && t.tipo !== 'transferencia_interna') return false;
+      else if (tipo === 'projecao' && t.tipo !== 'projecao') return false;
       else if (tipo === 'receita' && t._tipo !== 'receita') return false;
-      else if (tipo === 'despesa' && (t._tipo !== 'despesa' || t.tipo === 'projecao')) return false;
+      else if (tipo === 'despesa' && (t._tipo !== 'despesa' || t.tipo === 'projecao' || t.tipo === 'transferencia_interna')) return false;
     }
     // ENH-003: sentinela especial para transações sem categoria válida
     if (cat === '__nao_categorizada__') {
@@ -449,10 +450,23 @@ function renderizarPagina() {
       const catNome = catObj ? `${catObj.emoji ?? ''} ${catObj.nome}`.trim() : (t.categoriaId ?? '—');
       const resp    = t.responsavel ?? t.portador ?? '—';
 
+      // ENH-002: rota de transferência interna (portador → destino ou origem → portador)
+      let rotaTransf = '';
+      if (t.tipo === 'transferencia_interna') {
+        const portador = escHTML(t.portador ?? t.responsavel ?? '—');
+        if (t._tipo === 'despesa') {
+          const destNome = escHTML(_nomesMembros[t.membroDestinoId] ?? '?');
+          rotaTransf = `<div style="font-size:.7rem;color:var(--color-info-text);white-space:nowrap;margin-top:1px;">${portador} → ${destNome}</div>`;
+        } else {
+          const origNome = escHTML(_nomesMembros[t.membroOrigemId] ?? '?');
+          rotaTransf = `<div style="font-size:.7rem;color:var(--color-info-text);white-space:nowrap;margin-top:1px;">${origNome} → ${portador}</div>`;
+        }
+      }
+
       tr.innerHTML = `
         <td><input type="checkbox" class="ger-row-chk" data-id="${t.id}" data-colecao="${colecao}" ${checked} /></td>
         <td style="white-space:nowrap;">${dataStr}</td>
-        <td style="max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${escHTML(desc)}">${escHTML(desc)}</td>
+        <td style="max-width:220px;" title="${escHTML(desc)}"><div style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escHTML(desc)}</div>${rotaTransf}</td>
         <td style="text-align:right;font-weight:600;">${valorStr}</td>
         <td><span class="ger-tipo-badge ${tipoClass}">${tipoLabel}</span></td>
         <td style="max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escHTML(catNome)}</td>
@@ -492,12 +506,14 @@ function renderizarPagina() {
 }
 
 function _tipoLabel(t) {
+  if (t.tipo === 'transferencia_interna') return '🔁 Transferência';
   if (t.tipo === 'projecao') return '📆 Projeção';
   if (t._tipo === 'receita')  return '📥 Receita';
   return '💸 Despesa';
 }
 
 function _tipoClass(t) {
+  if (t.tipo === 'transferencia_interna') return 'ger-tipo-transf';
   if (t.tipo === 'projecao') return 'ger-tipo-projecao';
   if (t._tipo === 'receita')  return 'ger-tipo-receita';
   return 'ger-tipo-despesa';

--- a/tests/pages/base-dados.filtro.test.js
+++ b/tests/pages/base-dados.filtro.test.js
@@ -132,3 +132,105 @@ describe('ENH-003 Part 2: filtro de tipo em seletor de categorias (despesas.js)'
     expect(despesas).toHaveLength(3); // c1, c3, c4
   });
 });
+
+// ── ENH-002: filtro de tipo — transferencia_interna ──────────────────────────
+
+// Replica o predicado de tipo da aplicarFiltros() (base-dados.js):
+//
+//   if (tipo === 'transferencia_interna' && t.tipo !== 'transferencia_interna') return false;
+//   else if (tipo === 'projecao' && t.tipo !== 'projecao') return false;
+//   else if (tipo === 'receita' && t._tipo !== 'receita') return false;
+//   else if (tipo === 'despesa' && (t._tipo !== 'despesa' || t.tipo === 'projecao'
+//            || t.tipo === 'transferencia_interna')) return false;
+function passaFiltroTipo(t, tipo) {
+  if (tipo === 'todos') return true;
+  if (tipo === 'transferencia_interna' && t.tipo !== 'transferencia_interna') return false;
+  else if (tipo === 'projecao' && t.tipo !== 'projecao') return false;
+  else if (tipo === 'receita' && t._tipo !== 'receita') return false;
+  else if (tipo === 'despesa' && (t._tipo !== 'despesa' || t.tipo === 'projecao' || t.tipo === 'transferencia_interna')) return false;
+  return true;
+}
+
+// Replica _tipoLabel() de base-dados.js
+function tipoLabel(t) {
+  if (t.tipo === 'transferencia_interna') return '🔁 Transferência';
+  if (t.tipo === 'projecao') return '📆 Projeção';
+  if (t._tipo === 'receita') return '📥 Receita';
+  return '💸 Despesa';
+}
+
+// Replica _tipoClass() de base-dados.js
+function tipoClass(t) {
+  if (t.tipo === 'transferencia_interna') return 'ger-tipo-transf';
+  if (t.tipo === 'projecao') return 'ger-tipo-projecao';
+  if (t._tipo === 'receita') return 'ger-tipo-receita';
+  return 'ger-tipo-despesa';
+}
+
+describe('ENH-002: aplicarFiltros — filtro por tipo transferencia_interna', () => {
+  const transfDesp = { _tipo: 'despesa', tipo: 'transferencia_interna' };
+  const transfRec  = { _tipo: 'receita', tipo: 'transferencia_interna' };
+  const despNormal = { _tipo: 'despesa', tipo: 'despesa' };
+  const recNormal  = { _tipo: 'receita' };
+  const projecao   = { _tipo: 'despesa', tipo: 'projecao' };
+
+  it('filtra apenas transferencias quando tipo = transferencia_interna', () => {
+    expect(passaFiltroTipo(transfDesp, 'transferencia_interna')).toBe(true);
+    expect(passaFiltroTipo(transfRec,  'transferencia_interna')).toBe(true);
+  });
+
+  it('exclui despesas e receitas normais do filtro transferencia_interna', () => {
+    expect(passaFiltroTipo(despNormal, 'transferencia_interna')).toBe(false);
+    expect(passaFiltroTipo(recNormal,  'transferencia_interna')).toBe(false);
+  });
+
+  it('exclui transferencias do filtro despesa', () => {
+    expect(passaFiltroTipo(transfDesp, 'despesa')).toBe(false);
+    expect(passaFiltroTipo(transfRec,  'despesa')).toBe(false);
+  });
+
+  it('inclui despesas normais no filtro despesa (sem transferencias ou projecoes)', () => {
+    expect(passaFiltroTipo(despNormal, 'despesa')).toBe(true);
+  });
+
+  it('exclui projecoes do filtro despesa', () => {
+    expect(passaFiltroTipo(projecao, 'despesa')).toBe(false);
+  });
+
+  it('tipo todos passa qualquer transacao', () => {
+    expect(passaFiltroTipo(transfDesp, 'todos')).toBe(true);
+    expect(passaFiltroTipo(despNormal, 'todos')).toBe(true);
+    expect(passaFiltroTipo(recNormal,  'todos')).toBe(true);
+  });
+});
+
+describe('ENH-002: _tipoLabel — rótulo correto por tipo', () => {
+  it('transferencia_interna retorna rótulo de transferência', () => {
+    expect(tipoLabel({ tipo: 'transferencia_interna', _tipo: 'despesa' })).toBe('🔁 Transferência');
+    expect(tipoLabel({ tipo: 'transferencia_interna', _tipo: 'receita' })).toBe('🔁 Transferência');
+  });
+  it('projecao retorna rótulo de projeção', () => {
+    expect(tipoLabel({ tipo: 'projecao', _tipo: 'despesa' })).toBe('📆 Projeção');
+  });
+  it('receita retorna rótulo de receita', () => {
+    expect(tipoLabel({ _tipo: 'receita' })).toBe('📥 Receita');
+  });
+  it('despesa padrão retorna rótulo de despesa', () => {
+    expect(tipoLabel({ _tipo: 'despesa', tipo: 'despesa' })).toBe('💸 Despesa');
+  });
+});
+
+describe('ENH-002: _tipoClass — classe CSS correta por tipo', () => {
+  it('transferencia_interna retorna ger-tipo-transf', () => {
+    expect(tipoClass({ tipo: 'transferencia_interna' })).toBe('ger-tipo-transf');
+  });
+  it('projecao retorna ger-tipo-projecao', () => {
+    expect(tipoClass({ tipo: 'projecao' })).toBe('ger-tipo-projecao');
+  });
+  it('receita retorna ger-tipo-receita', () => {
+    expect(tipoClass({ _tipo: 'receita' })).toBe('ger-tipo-receita');
+  });
+  it('despesa normal retorna ger-tipo-despesa', () => {
+    expect(tipoClass({ _tipo: 'despesa', tipo: 'despesa' })).toBe('ger-tipo-despesa');
+  });
+});


### PR DESCRIPTION
## O que foi feito

- Linhas `tipo=transferencia_interna` na Base de Dados exibem subtítulo de rota: `portador → destino` (despesa) ou `origem → portador` (receita), resolvido via `_nomesMembros` do grupo
- Novo badge "🔁 Transferência" com classe `ger-tipo-transf` (cor info — `--color-info-light/text`)
- Novo filtro "🔁 Transferências Internas" no seletor de tipo da aba Gerenciar
- Filtro "💸 Despesas" atualizado para excluir `transferencia_interna` da listagem
- Fix XSS pré-existente (Medium): `escHTML()` adicionado em `preencherSelResp()` para nomes de membros no seletor de ação em lote

## Subagentes

- test-runner: **PASS** — 679/679 (14 novos testes ENH-002)
- security-reviewer: **PASS** — ENH-002 limpo; fix XSS Medium pré-existente incluído neste PR
- import-pipeline-reviewer: N/A

## Como testar

- [ ] `npm test` (679 passando)
- [ ] `npm run build`
- [ ] Base de Dados → aba Gerenciar → filtrar "🔁 Transferências Internas" → verificar linhas com subtítulo de rota
- [ ] Filtrar "💸 Despesas" → confirmar ausência de transferências
- [ ] Confirmar badge azul "🔁 Transferência" em rows de transferência

## Checklist

- [x] Sem credenciais Firebase no diff
- [x] CHANGELOG.md atualizado (v3.35.0)
- [x] CSS usa variáveis de variables.css (`--color-info-light`, `--color-info-text`)
- [x] chave_dedup intacta
- [x] grupoId presente em todas as queries Firestore
- [x] escHTML() em todo innerHTML com dados do usuário (incluindo fix pré-existente)
- [x] onSnapshot: sem mudanças — unsubscribe existente preservado