### PR TITLE
feat(despesas): ENH-004 — progressive disclosure, 1 badge por linha (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.36.0] - 2026-04-19
+
+### Adicionado
+
+- **ENH-004: progressive disclosure — 1 badge visível por linha de despesa (#151):** a listagem de despesas exibia até 6 badges simultâneos (conta, portador, parcela, projeção, conjunta, transferência). Agora o estado compacto exibe no máximo 1 badge de acordo com a hierarquia de prioridade: `transferência > projeção > parcela X/Y > conjunta > portador`. Um toggle `▾` aparece quando há mais de 1 metadado disponível, abrindo um painel expansível (`<details>`/`<summary>` nativo — zero JS extra) com todos os badges. Sem regressão em editar/excluir/filtrar. 679 testes passando.
+
 ## [3.35.0] - 2026-04-19
 
 ### Adicionado

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -314,6 +314,13 @@ a:hover { text-decoration: underline; }
 .desp-chip-resp .desp-chip-label { color: var(--color-primary); }
 .desp-chip-resp .desp-chip-valor { color: var(--color-primary); font-weight: 700; }
 .desp-item-meta { display: flex; align-items: center; flex-wrap: wrap; gap: .35rem; margin-top: .2rem; }
+/* ENH-004: progressive disclosure — painel expansível de metadados */
+.desp-detail { display: inline-flex; align-items: center; }
+.desp-detail[open] { flex-basis: 100%; flex-direction: column; align-items: flex-start; }
+.desp-detail-toggle { font-size: .68rem; color: var(--color-text-muted); cursor: pointer; padding: .1rem .3rem; border-radius: var(--radius-sm); list-style: none; user-select: none; line-height: 1.2; }
+.desp-detail-toggle::-webkit-details-marker { display: none; }
+.desp-detail[open] .desp-detail-toggle { color: var(--color-text-secondary); }
+.desp-detail-panel { display: flex; flex-wrap: wrap; gap: .3rem; padding-top: .25rem; }
 .desp-resp-badge { font-size: var(--font-size-xs); font-weight: 600; padding: .1rem .45rem; border-radius: var(--radius-full); background: var(--color-info-light); color: var(--color-info-text); border: 1px solid var(--color-info-border); }
 .desp-resp-badge--conjunta { background: var(--color-conjunta-light); color: var(--color-conjunta); border-color: var(--color-conjunta-border); }
 /* NRF-004: badge de conta/banco — cor dinâmica via inline style */

--- a/src/js/pages/despesas.js
+++ b/src/js/pages/despesas.js
@@ -359,7 +359,7 @@ function renderizarLista() {
     const portBadge = d.isConjunta
       ? `<span class="desp-resp-badge desp-resp-badge--conjunta">👫 compartilhada</span>`
       : (d.responsavel || d.portador)
-        ? `<span class="desp-resp-badge">${(d.responsavel || d.portador).split(' ')[0]}</span>`
+        ? `<span class="desp-resp-badge">${escHTML((d.responsavel || d.portador).split(' ')[0])}</span>`
         : '';
     const parcelaBadge = (d.parcela && d.parcela !== '-')
       ? `<span class="desp-parcela-badge">${d.parcela}</span>`
@@ -382,6 +382,22 @@ function renderizarLista() {
       ? '<span class="desp-transf-badge" title="Transferência entre membros do grupo — excluída dos agregados">🔁 transferência interna</span>'
       : '';
 
+    // ENH-004: 1 badge visível no estado compacto (hierarquia: transf > projeção > parcela > conjunta > portador)
+    let compactBadge = '';
+    if (isTransf)                          compactBadge = transfBadge;
+    else if (isProj)                       compactBadge = projBadge;
+    else if (d.parcela && d.parcela !== '-') compactBadge = parcelaBadge;
+    else if (d.isConjunta)                 compactBadge = conjuntaBadge;
+    else if (portBadge)                    compactBadge = portBadge;
+
+    // ENH-004: painel expansível com todos os metadados
+    const allBadges = [contaBadge, portBadge, parcelaBadge, projBadge, conjuntaBadge, transfBadge].filter(Boolean);
+    const detailPanel = allBadges.length > 1 ? `
+      <details class="desp-detail">
+        <summary class="desp-detail-toggle">▾</summary>
+        <div class="desp-detail-panel">${allBadges.join('')}</div>
+      </details>` : '';
+
     return `
     <div class="desp-item card${isProj ? ' desp-item--proj' : ''}${isTransf ? ' desp-item--transf' : ''}">
       <div class="desp-item-left">
@@ -389,7 +405,7 @@ function renderizarLista() {
         <span class="desp-item-descricao">${escHTML(d.descricao)}</span>
         <div class="desp-item-meta">
           <span class="desp-item-data">${dataFmt}</span>
-          ${contaBadge}${portBadge}${parcelaBadge}${projBadge}${conjuntaBadge}${transfBadge}
+          ${compactBadge}${detailPanel}
         </div>
       </div>
       <div class="desp-item-right">


### PR DESCRIPTION
## O que foi feito

- A listagem de despesas exibia até 6 badges simultâneos por item (conta, portador, parcela, projeção, conjunta, transferência) — impossível de escanear
- Estado compacto agora exibe no máximo 1 badge de acordo com a hierarquia: `transferência > projeção > parcela X/Y > conjunta > portador`
- Toggle `▾` aparece quando há mais de 1 metadado disponível, expandindo painel `<details>`/`<summary>` nativo com todos os badges
- Fix XSS pré-existente (Medium): `escHTML()` adicionado em `portBadge` para `d.responsavel`/`d.portador`

## Subagentes

- test-runner: **PASS** — 679/679
- security-reviewer: **PASS** — ENH-004 limpo; fix XSS Medium pré-existente incluído
- import-pipeline-reviewer: N/A

## Como testar

- [ ] `npm test` (679 passando)
- [ ] `npm run build`
- [ ] Despesas → verificar que cada linha exibe apenas 1 badge no estado compacto
- [ ] Clicar `▾` → confirmar abertura do painel com todos os metadados
- [ ] Testar viewport 375px (mobile)
- [ ] Confirmar que editar/excluir/filtrar funcionam sem regressão

## Checklist

- [x] Sem credenciais Firebase no diff
- [x] CHANGELOG.md atualizado (v3.36.0)
- [x] CSS usa variáveis de variables.css
- [x] escHTML() em todo innerHTML com dados do usuário (incluindo fix pré-existente)
- [x] Sem mudanças em lógica de filtro, Firestore ou chave_dedup
- [x] onSnapshot: sem mudanças