### PR TITLE
feat(nav): NRF-NAV Fase 2 — projecoesCartao.js + Compromissos em Futuro + Cockpit (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.37.0] - 2026-04-20
+
+### Adicionado
+
+- **NRF-NAV Fase 2: consolidação Projeções×Futuro + Planejamento→Cockpit (#186):** extração de `carregarProjecoes()` + `renderizarProjecoes()` de `fatura.js` para novo módulo reutilizável `src/js/utils/projecoesCartao.js` com duas exports: `iniciar(grupoId, cartaoId, mes, ano, onUpdate)` → listener em tempo real por cartão (retorna array de unsubscribes; caller gerencia cleanup, zero leak) e `buscarProjecoesAgregadas(grupoId, mes, ano)` → one-shot fetch de todos os cartões agregados por `mesFatura`. Nova seção "📅 Compromissos Comprometidos — Próximos 6 Meses" adicionada a `fluxo-caixa.html` (âncora `#compromissos`) consumindo o módulo para agregar parcelas importadas de todos os cartões. Link sutil "ver todos os cartões consolidados em Futuro →" adicionado à aba Projeções de `fatura.html`. Navbar refatorada: `planejamento.html` migrado da seção Futuro para nova seção **Cockpit** (agora `<details>` com sub-itens Dashboard + Planejamento) em todos os 11 HTMLs; `nav.js` atualizado com `planejamento: 'cockpit'` no sectionMap (Q2=Cockpit, decisão PO 2026-04-20). 11 novos testes em `tests/utils/projecoesCartao.test.js`. 690 testes passando.
+
+### Modificado
+
+- `src/js/pages/fatura.js`: `carregarProjecoes()` refatorado para delegar ao módulo `projecoesCartao.js`; cleanup de `_unsubProjecoes[]` garantido ao recarregar; cálculo `porMembro` permanece em fatura.js (acesso a `_membrosDoGrupo()`).
+- `src/js/pages/fluxo-caixa.js`: `carregarForecast()` e novo `carregarCompromissos()` rodando em paralelo via `Promise.all`.
+- `src/js/nav.js`: `planejamento` mapeado para seção `cockpit` (antes `futuro`); branch especial de ativação do Cockpit removida (agora usa lógica genérica de `<details>`).
+
 ## [3.36.0] - 2026-04-19
 
 ### Adicionado

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.36.0",
+  "version": "3.37.0",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/src/base-dados.html
+++ b/src/base-dados.html
@@ -23,10 +23,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -35,7 +42,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/categorias.html
+++ b/src/categorias.html
@@ -23,10 +23,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -35,7 +42,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/contas.html
+++ b/src/contas.html
@@ -23,10 +23,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -35,7 +42,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -944,6 +944,9 @@ a:hover { text-decoration: underline; }
 
 /* Projeções */
 .fat-loading { text-align: center; color: var(--color-text-muted); padding: var(--space-6); font-style: italic; }
+.fat-proj-link-futuro { text-align: right; padding: var(--space-3) var(--space-4) var(--space-2); font-size: var(--font-size-sm); }
+.link-sutil { color: var(--color-text-muted); text-decoration: none; }
+.link-sutil:hover { color: var(--color-primary); text-decoration: underline; }
 
 /* ── RF-019: Badge de conta aplicada automaticamente ── */
 .imp-conta-auto-badge {

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -26,10 +26,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -38,7 +45,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/despesas.html
+++ b/src/despesas.html
@@ -23,10 +23,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -35,7 +42,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/fatura.html
+++ b/src/fatura.html
@@ -23,10 +23,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -35,7 +42,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/fluxo-caixa.html
+++ b/src/fluxo-caixa.html
@@ -26,10 +26,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -38,7 +45,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>
@@ -205,6 +211,34 @@
           <span><strong>Parcelas</strong> = comprometido (certo)</span>
           <span>·</span>
           <span><strong>Variáveis</strong> = teto de orçamento</span>
+        </div>
+      </div>
+
+      <!-- ═══ SEÇÃO: COMPROMISSOS COMPROMETIDOS (NRF-NAV F2) ═══ -->
+      <div class="card fc-forecast-card" id="compromissos">
+        <div class="fc-forecast-header">
+          <div class="fc-forecast-titulo-row">
+            <h3 class="fc-tabela-titulo">📅 Compromissos Comprometidos — Próximos 6 Meses</h3>
+            <span class="fc-forecast-subtitulo">Parcelas futuras importadas — todos os cartões agregados</span>
+          </div>
+        </div>
+        <div class="fc-tabela-scroll">
+          <table class="fc-tabela">
+            <thead>
+              <tr>
+                <th>Mês</th>
+                <th class="fc-th-num">Total Comprometido</th>
+              </tr>
+            </thead>
+            <tbody id="fc-compromissos-tbody">
+              <tr><td colspan="2" class="fc-empty">Carregando compromissos...</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="fc-forecast-legenda">
+          <span>Fonte: parcelas importadas com tipo <strong>projeção</strong> — certeza, não estimativa</span>
+          <span>·</span>
+          <span><a href="fatura.html?tab=projecoes" class="link-sutil">ver por cartão →</a></span>
         </div>
       </div>
 

--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -27,7 +27,7 @@
 
   const sectionMap = {
     dashboard:    'cockpit',
-    planejamento: 'futuro',
+    planejamento: 'cockpit',
     patrimonio:   'historico',
     importar:     'transacoes',
     fatura:       'transacoes',
@@ -45,10 +45,7 @@
   // fatura?tab=projecoes → seção Futuro
   if (page === 'fatura' && params.get('tab') === 'projecoes') section = 'futuro';
 
-  if (section === 'cockpit') {
-    const cockpit = navEl.querySelector('.nav-section-btn[data-page="dashboard"]');
-    cockpit?.setAttribute('data-active', '');
-  } else if (section) {
+  if (section) {
     const group = navEl.querySelector(`.nav-section-group[data-section="${section}"]`);
     if (group) {
       group.setAttribute('open', '');

--- a/src/js/pages/fatura.js
+++ b/src/js/pages/fatura.js
@@ -15,6 +15,7 @@ import { formatarMoeda, formatarData, nomeMes, escHTML } from '../utils/formatte
 import { recalcularScoreFatura } from '../utils/reconciliadorFatura.js';
 import { skeletonTableRows, errorStateHTML } from '../utils/skeletons.js';
 import { CONTAS_PADRAO } from '../models/Conta.js';
+import { iniciar as iniciarProjecoes } from '../utils/projecoesCartao.js';
 
 // ── Estado ────────────────────────────────────────────────────
 let _usuario    = null;
@@ -35,6 +36,7 @@ let _unsubContas        = null;
 let _unsubCats          = null;
 let _unsubDesp          = null;
 let _unsubDespMesFatura = null;  // BUG-022: listener paralelo por mesFatura
+let _unsubProjecoes     = [];    // NRF-NAV F2: listeners do módulo projecoesCartao
 
 // ── Inicialização ─────────────────────────────────────────────
 onAuthChange(async (user) => {
@@ -115,7 +117,7 @@ function preencherSeletorCartao() {
   sel.innerHTML = '<option value="">— selecione —</option>' +
     cartoes.map(c => {
       const tag = c._legado ? ' (legado)' : '';
-      return `<option value="${c.id}">${c.emoji} ${c.nome}${tag}</option>`;
+      return `<option value="${escHTML(c.id)}">${escHTML(c.emoji)} ${escHTML(c.nome)}${escHTML(tag)}</option>`;
     }).join('');
   if (anterior && cartoes.find(c => c.id === anterior)) {
     sel.value = anterior;
@@ -405,56 +407,31 @@ function renderizarResumoDetalhado(membros) {
 }
 
 // ── Projeções futuras ─────────────────────────────────────────
-async function carregarProjecoes() {
+function carregarProjecoes() {
+  _unsubProjecoes.forEach(fn => fn());
+  _unsubProjecoes = [];
+
   const container = document.getElementById('fat-proj-content');
   container.innerHTML = '<p class="fat-loading">Carregando...</p>';
   if (!_cartaoId) { container.innerHTML = '<p class="fat-loading">Selecione um cartão.</p>'; return; }
 
-  // Carrega próximos 6 meses de projeções (parcelas pendentes)
-  const projecoesPorMes = {};
-  const hoje = new Date();
-  const inicio = new Date(_ano, _mes - 1, 1); // mês atual + 1
-  inicio.setMonth(inicio.getMonth() + 1);
-
-  for (let i = 0; i < 6; i++) {
-    const m = new Date(inicio);
-    m.setMonth(m.getMonth() + i);
-    projecoesPorMes[`${m.getFullYear()}-${m.getMonth() + 1}`] = {
-      mes: m.getMonth() + 1, ano: m.getFullYear(), total: 0, porMembro: {}
-    };
-  }
-
-  // Usa os dados já importados (projeções são status='pendente' com data futura)
-  // Cria listeners para cada mês futuro
   const membros = _membrosDoGrupo();
-  let pendentes = 0;
-  const unsubProjs = [];
 
-  for (let i = 0; i < 6; i++) {
-    const m = new Date(inicio);
-    m.setMonth(m.getMonth() + i);
-    const mes = m.getMonth() + 1, ano = m.getFullYear();
-    const key = `${ano}-${mes}`;
-
-    const unsub = ouvirDespesas(_grupoId, mes, ano, (desp) => {
-      const filtradas = desp.filter(d => d.contaId === _cartaoId && d.tipo === 'projecao');
-      projecoesPorMes[key] = { mes, ano, total: 0, porMembro: {}, despesas: filtradas };
-
-      // Calcula por membro
+  _unsubProjecoes = iniciarProjecoes(_grupoId, _cartaoId, _mes, _ano, (dadosPorMes) => {
+    // Enriquecer com porMembro antes de renderizar
+    Object.values(dadosPorMes).forEach(entry => {
+      entry.porMembro = {};
       membros.forEach(memb => {
-        const ind = filtradas.filter(d => !d.isConjunta && (d.responsavel || d.portador || '').toLowerCase().startsWith(memb.key));
-        const conj = filtradas.filter(d => d.isConjunta);
+        const ind  = entry.despesas.filter(d => !d.isConjunta && (d.responsavel || d.portador || '').toLowerCase().startsWith(memb.key));
+        const conj = entry.despesas.filter(d => d.isConjunta);
         const tInd  = ind.reduce((s, d) => s + (d.valor ?? 0), 0);
         const tConj = conj.reduce((s, d) => s + (d.valorAlocado ?? (d.valor ?? 0) / 2), 0);
-        projecoesPorMes[key].porMembro[memb.key] = tInd + tConj;
+        entry.porMembro[memb.key] = tInd + tConj;
       });
-      projecoesPorMes[key].total = Object.values(projecoesPorMes[key].porMembro).reduce((s, v) => s + v, 0);
-
-      pendentes++;
-      if (pendentes >= 6) renderizarProjecoes(projecoesPorMes, membros);
+      entry.total = Object.values(entry.porMembro).reduce((s, v) => s + v, 0);
     });
-    unsubProjs.push(unsub);
-  }
+    renderizarProjecoes(dadosPorMes, membros);
+  });
 }
 
 function renderizarProjecoes(projecoesPorMes, membros) {
@@ -488,7 +465,10 @@ function renderizarProjecoes(projecoesPorMes, membros) {
         </tr></thead>
         <tbody>${rows}</tbody>
       </table>
-    </div>`;
+    </div>
+    <p class="fat-proj-link-futuro">
+      <a href="fluxo-caixa.html#compromissos" class="link-sutil">📊 ver todos os cartões consolidados em Futuro →</a>
+    </p>`;
 }
 
 // ── Tabs ──────────────────────────────────────────────────────

--- a/src/js/pages/fluxo-caixa.js
+++ b/src/js/pages/fluxo-caixa.js
@@ -16,6 +16,7 @@ import {
 import { gerarForecast } from '../utils/forecastEngine.js';
 import { coresGrafico } from '../utils/chartColors.js';
 import { isMovimentacaoReal } from '../utils/helpers.js';
+import { buscarProjecoesAgregadas } from '../utils/projecoesCartao.js';
 
 // ── Constantes ────────────────────────────────────────────────
 
@@ -108,8 +109,8 @@ async function carregarFluxo() {
   } finally {
     mostrarLoading(false);
   }
-  // Forecast: sempre baseado na data atual (independente do ano selecionado)
-  await carregarForecast();
+  // Forecast e compromissos: sempre baseados na data atual
+  await Promise.all([carregarForecast(), carregarCompromissos()]);
 }
 
 function agregarMensalmente(despesas, receitas, orcamentos) {
@@ -444,4 +445,38 @@ function renderizarForecast(forecast) {
  */
 function escMesLabel(label, ano) {
   return `${label}/${String(ano).slice(2)}`;
+}
+
+// ── NRF-NAV F2: Compromissos Comprometidos ────────────────────
+
+async function carregarCompromissos() {
+  const tbody = document.getElementById('fc-compromissos-tbody');
+  if (!tbody) return;
+
+  try {
+    const hoje = new Date();
+    const dadosPorMes = await buscarProjecoesAgregadas(_grupoId, hoje.getMonth() + 1, hoje.getFullYear());
+    const meses = Object.values(dadosPorMes).sort((a, b) =>
+      a.ano !== b.ano ? a.ano - b.ano : a.mes - b.mes
+    );
+
+    const temDados = meses.some(m => m.total > 0);
+    if (!temDados) {
+      tbody.innerHTML = '<tr><td colspan="2" class="fc-empty">Nenhuma parcela comprometida nos próximos 6 meses.</td></tr>';
+      return;
+    }
+
+    tbody.innerHTML = meses.map(({ mes, ano, total }) => {
+      if (total === 0) return '';
+      const saldoCls = 'fc-vermelho';
+      return `<tr class="fc-tr--futuro">
+        <td class="fc-td-mes">${MESES_COMPLETOS[mes - 1]} ${ano}</td>
+        <td class="fc-td-num ${saldoCls}">${fmt(total)}</td>
+      </tr>`;
+    }).filter(Boolean).join('');
+  } catch (err) {
+    console.error('[fluxo-caixa] Erro ao carregar compromissos:', err);
+    const tbody2 = document.getElementById('fc-compromissos-tbody');
+    if (tbody2) tbody2.innerHTML = '<tr><td colspan="2" class="fc-empty">Erro ao carregar compromissos.</td></tr>';
+  }
 }

--- a/src/js/utils/projecoesCartao.js
+++ b/src/js/utils/projecoesCartao.js
@@ -1,0 +1,93 @@
+// ============================================================
+// projecoesCartao.js — Módulo reutilizável de projeções de cartão
+// NRF-NAV Fase 2 (#186) — extração de fatura.js para uso compartilhado
+// ============================================================
+
+import { ouvirDespesas } from '../services/database.js';
+import { buscarProjecoesRange } from '../services/database.js';
+
+/**
+ * Inicia listeners em tempo real de projeções de um cartão específico
+ * para os próximos 6 meses a partir do mês/ano fornecido.
+ *
+ * @param {string} grupoId   - ID do grupo familiar
+ * @param {string} cartaoId  - contaId do cartão filtrado
+ * @param {number} mes       - mês de referência (1-12)
+ * @param {number} ano       - ano de referência (ex: 2026)
+ * @param {function} onUpdate - callback chamado com dadosPorMes quando dados mudam
+ * @returns {Function[]} array de unsubscribes — caller gerencia cleanup
+ *
+ * dadosPorMes format: { [key: string]: { mes, ano, total, despesas[] } }
+ * onde key = "YYYY-M"
+ */
+export function iniciar(grupoId, cartaoId, mes, ano, onUpdate) {
+  const unsubscribes = [];
+  const dadosPorMes = {};
+  const respondidos = new Set();
+
+  const inicio = new Date(ano, mes - 1, 1);
+  inicio.setMonth(inicio.getMonth() + 1);
+
+  for (let i = 0; i < 6; i++) {
+    const m = new Date(inicio);
+    m.setMonth(m.getMonth() + i);
+    const mMes = m.getMonth() + 1;
+    const mAno = m.getFullYear();
+    const key = `${mAno}-${mMes}`;
+
+    dadosPorMes[key] = { mes: mMes, ano: mAno, total: 0, despesas: [] };
+
+    const unsub = ouvirDespesas(grupoId, mMes, mAno, (desp) => {
+      const filtradas = desp.filter(d => d.contaId === cartaoId && d.tipo === 'projecao');
+      dadosPorMes[key] = {
+        mes: mMes,
+        ano: mAno,
+        total: filtradas.reduce((s, d) => s + (d.valor ?? 0), 0),
+        despesas: filtradas,
+      };
+      respondidos.add(key);
+      if (respondidos.size >= 6) onUpdate({ ...dadosPorMes });
+    });
+    unsubscribes.push(unsub);
+  }
+
+  return unsubscribes;
+}
+
+/**
+ * Busca pontual (one-shot) de projeções de todos os cartões para os próximos
+ * 6 meses. Filtra por mesFatura para precisão de ciclo de faturamento.
+ * Usado pela página fluxo-caixa.js para agregação entre cartões.
+ *
+ * @param {string} grupoId - ID do grupo familiar
+ * @param {number} mes     - mês de referência (1-12)
+ * @param {number} ano     - ano de referência
+ * @returns {Promise<{ [mesFatura: string]: { mes, ano, total, despesas[] } }>}
+ */
+export async function buscarProjecoesAgregadas(grupoId, mes, ano) {
+  const inicio = new Date(ano, mes - 1, 1);
+  inicio.setMonth(inicio.getMonth() + 1);
+  const fim = new Date(inicio);
+  fim.setMonth(fim.getMonth() + 5);
+
+  const fmt = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+  const todasProjecoes = await buscarProjecoesRange(grupoId, fmt(inicio), fmt(fim));
+
+  const resultado = {};
+  for (let i = 0; i < 6; i++) {
+    const m = new Date(inicio);
+    m.setMonth(m.getMonth() + i);
+    const key = fmt(m);
+    resultado[key] = { mes: m.getMonth() + 1, ano: m.getFullYear(), total: 0, despesas: [] };
+  }
+
+  todasProjecoes.forEach(d => {
+    const key = d.mesFatura;
+    if (resultado[key]) {
+      resultado[key].despesas.push(d);
+      resultado[key].total += d.valor ?? 0;
+    }
+  });
+
+  return resultado;
+}

--- a/src/orcamentos.html
+++ b/src/orcamentos.html
@@ -23,10 +23,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -35,7 +42,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/patrimonio.html
+++ b/src/patrimonio.html
@@ -25,10 +25,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -37,7 +44,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/planejamento.html
+++ b/src/planejamento.html
@@ -24,10 +24,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -36,7 +43,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/src/receitas.html
+++ b/src/receitas.html
@@ -23,10 +23,17 @@
       </a>
     </div>
     <nav class="nav-sections" id="nav-sections">
-      <a href="dashboard.html" class="nav-section-btn" data-page="dashboard">
-        <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
-        <span>Cockpit</span>
-      </a>
+      <details class="nav-section-group" data-section="cockpit">
+        <summary class="nav-section-btn">
+          <i data-lucide="layout-dashboard" class="nav-section-icon"></i>
+          <span>Cockpit</span>
+          <i data-lucide="chevron-down" class="nav-chevron"></i>
+        </summary>
+        <div class="nav-sub-menu">
+          <a href="dashboard.html" class="nav-sub-item" data-page="dashboard">🏠 Dashboard</a>
+          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
+        </div>
+      </details>
       <details class="nav-section-group" data-section="futuro">
         <summary class="nav-section-btn">
           <i data-lucide="trending-up" class="nav-section-icon"></i>
@@ -35,7 +42,6 @@
         </summary>
         <div class="nav-sub-menu">
           <a href="fluxo-caixa.html" class="nav-sub-item" data-page="fluxo-caixa">🔮 Forecast</a>
-          <a href="planejamento.html" class="nav-sub-item" data-page="planejamento">📋 Planejamento</a>
           <a href="fatura.html?tab=projecoes" class="nav-sub-item">💳 Projeções</a>
         </div>
       </details>

--- a/tests/utils/projecoesCartao.test.js
+++ b/tests/utils/projecoesCartao.test.js
@@ -1,0 +1,194 @@
+// ============================================================
+// Testes — projecoesCartao.js (NRF-NAV F2 #186)
+// Cobre: iniciar() (listener) + buscarProjecoesAgregadas() (one-shot)
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ─────────────────────────────────────────────────────
+
+vi.mock('../../src/js/services/database.js', () => ({
+  ouvirDespesas: vi.fn(),
+  buscarProjecoesRange: vi.fn(),
+}));
+
+import { ouvirDespesas, buscarProjecoesRange } from '../../src/js/services/database.js';
+import { iniciar, buscarProjecoesAgregadas } from '../../src/js/utils/projecoesCartao.js';
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function mkProj({ contaId = 'c1', valor = 100, isConjunta = false, mesFatura = '2026-05', valorAlocado = null } = {}) {
+  return { contaId, valor, tipo: 'projecao', isConjunta, mesFatura, valorAlocado };
+}
+
+function mkUnsub() {
+  return vi.fn();
+}
+
+// ── iniciar() ─────────────────────────────────────────────────
+
+describe('iniciar', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('retorna 6 unsubscribes', () => {
+    ouvirDespesas.mockReturnValue(mkUnsub());
+    const unsubs = iniciar('g1', 'c1', 4, 2026, vi.fn());
+    expect(unsubs).toHaveLength(6);
+    expect(ouvirDespesas).toHaveBeenCalledTimes(6);
+  });
+
+  it('filtra apenas tipo=projecao do cartaoId correto', () => {
+    const onUpdate = vi.fn();
+    let capturedCallbacks = [];
+    ouvirDespesas.mockImplementation((grupoId, mes, ano, cb) => {
+      capturedCallbacks.push({ mes, cb });
+      return mkUnsub();
+    });
+
+    iniciar('g1', 'c1', 4, 2026, onUpdate);
+
+    // Simula snapshot com despesas mistas
+    capturedCallbacks.forEach(({ cb }) => {
+      cb([
+        mkProj({ contaId: 'c1', valor: 200 }),      // deve incluir
+        mkProj({ contaId: 'outro', valor: 999 }),    // cartão errado — ignorar
+        { contaId: 'c1', valor: 50, tipo: 'despesa' }, // tipo errado — ignorar
+      ]);
+    });
+
+    // onUpdate chamado após 6 respostas, total = 200 * 6
+    expect(onUpdate).toHaveBeenCalled();
+    const dadosPorMes = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
+    Object.values(dadosPorMes).forEach(entry => {
+      expect(entry.total).toBe(200);
+      expect(entry.despesas).toHaveLength(1);
+    });
+  });
+
+  it('não chama onUpdate antes de todas as 6 respostas chegarem', () => {
+    const onUpdate = vi.fn();
+    let callbacks = [];
+    ouvirDespesas.mockImplementation((grupoId, mes, ano, cb) => {
+      callbacks.push(cb);
+      return mkUnsub();
+    });
+
+    iniciar('g1', 'c1', 4, 2026, onUpdate);
+
+    // Dispara apenas 5 dos 6 callbacks
+    callbacks.slice(0, 5).forEach(cb => cb([]));
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    // 6ª resposta dispara onUpdate
+    callbacks[5]([]);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('continua chamando onUpdate após atualização subsequente', () => {
+    const onUpdate = vi.fn();
+    let callbacks = [];
+    ouvirDespesas.mockImplementation((grupoId, mes, ano, cb) => {
+      callbacks.push(cb);
+      return mkUnsub();
+    });
+
+    iniciar('g1', 'c1', 4, 2026, onUpdate);
+
+    // Todas as 6 respondem
+    callbacks.forEach(cb => cb([]));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    // Atualização em tempo real de um listener
+    callbacks[0]([mkProj({ contaId: 'c1', valor: 300 })]);
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('agrupa meses corretamente (próximos 6 a partir do mês seguinte)', () => {
+    const onUpdate = vi.fn();
+    let mesAnoCapturados = [];
+    ouvirDespesas.mockImplementation((grupoId, mes, ano, cb) => {
+      mesAnoCapturados.push({ mes, ano });
+      cb([]);
+      return mkUnsub();
+    });
+
+    iniciar('g1', 'c1', 12, 2026, onUpdate);
+
+    // Começando de Dez/2026, próximos 6 = Jan-Jun/2027
+    expect(mesAnoCapturados[0]).toEqual({ mes: 1, ano: 2027 });
+    expect(mesAnoCapturados[5]).toEqual({ mes: 6, ano: 2027 });
+  });
+
+  it('retorna total zero quando não há projeções para o cartão', () => {
+    const onUpdate = vi.fn();
+    ouvirDespesas.mockImplementation((grupoId, mes, ano, cb) => {
+      cb([]);
+      return mkUnsub();
+    });
+
+    iniciar('g1', 'c1', 4, 2026, onUpdate);
+
+    expect(onUpdate).toHaveBeenCalled();
+    const dadosPorMes = onUpdate.mock.calls[0][0];
+    Object.values(dadosPorMes).forEach(entry => {
+      expect(entry.total).toBe(0);
+      expect(entry.despesas).toHaveLength(0);
+    });
+  });
+});
+
+// ── buscarProjecoesAgregadas() ────────────────────────────────
+
+describe('buscarProjecoesAgregadas', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('retorna 6 meses no resultado mesmo sem projeções', async () => {
+    buscarProjecoesRange.mockResolvedValue([]);
+    const resultado = await buscarProjecoesAgregadas('g1', 4, 2026);
+    expect(Object.keys(resultado)).toHaveLength(6);
+    Object.values(resultado).forEach(entry => {
+      expect(entry.total).toBe(0);
+      expect(entry.despesas).toHaveLength(0);
+    });
+  });
+
+  it('agrega totais por mesFatura corretamente', async () => {
+    buscarProjecoesRange.mockResolvedValue([
+      mkProj({ mesFatura: '2026-05', valor: 150 }),
+      mkProj({ mesFatura: '2026-05', valor: 250 }),
+      mkProj({ mesFatura: '2026-07', valor: 400 }),
+    ]);
+    const resultado = await buscarProjecoesAgregadas('g1', 4, 2026);
+    expect(resultado['2026-05'].total).toBe(400);
+    expect(resultado['2026-05'].despesas).toHaveLength(2);
+    expect(resultado['2026-07'].total).toBe(400);
+  });
+
+  it('ignora projeções fora do range de 6 meses', async () => {
+    buscarProjecoesRange.mockResolvedValue([
+      mkProj({ mesFatura: '2025-01', valor: 999 }), // fora do range
+      mkProj({ mesFatura: '2026-05', valor: 100 }),
+    ]);
+    const resultado = await buscarProjecoesAgregadas('g1', 4, 2026);
+    expect(resultado['2026-05'].total).toBe(100);
+    // 2025-01 não aparece no resultado
+    expect(resultado['2025-01']).toBeUndefined();
+  });
+
+  it('chama buscarProjecoesRange com range correto (próximos 6 meses)', async () => {
+    buscarProjecoesRange.mockResolvedValue([]);
+    await buscarProjecoesAgregadas('g1', 12, 2026);
+    // Dez/2026 → próximos 6 = Jan-Jun/2027
+    expect(buscarProjecoesRange).toHaveBeenCalledWith('g1', '2027-01', '2027-06');
+  });
+
+  it('passa grupoId corretamente para buscarProjecoesRange', async () => {
+    buscarProjecoesRange.mockResolvedValue([]);
+    await buscarProjecoesAgregadas('grupo-abc', 4, 2026);
+    expect(buscarProjecoesRange).toHaveBeenCalledWith('grupo-abc', expect.any(String), expect.any(String));
+  });
+});


### PR DESCRIPTION
## O que foi feito

- **Novo módulo** `src/js/utils/projecoesCartao.js` com duas exports:
  - `iniciar(grupoId, cartaoId, mes, ano, onUpdate)` → listener em tempo real por cartão, retorna `unsubscribes[]`
  - `buscarProjecoesAgregadas(grupoId, mes, ano)` → one-shot fetch de todos os cartões via `mesFatura`
- **fatura.js**: `carregarProjecoes()` refatorado para consumir o módulo; cleanup de `_unsubProjecoes[]` garantido ao recarregar; `renderizarProjecoes()` mantido em fatura.js com cálculo `porMembro`; link sutil "ver consolidado em Futuro →" adicionado na aba Projeções
- **fix HIGH-001** (security review): `escHTML()` adicionado em `c.id`, `c.emoji`, `c.nome` em `preencherSeletorCartao()` — dado do Firestore em innerHTML sem sanitização
- **fluxo-caixa.html**: nova seção `#compromissos` "📅 Compromissos Comprometidos — Próximos 6 Meses" com tabela agregada de todos os cartões
- **fluxo-caixa.js**: `carregarCompromissos()` em `Promise.all` com `carregarForecast()`
- **Navbar (11 HTMLs)**: Cockpit convertido de `<a>` para `<details>` com sub-itens Dashboard + Planejamento; Planejamento removido de Futuro
- **nav.js**: `planejamento: 'cockpit'` no sectionMap; branch especial cockpit removida (genérica funciona)
- **CSS**: `.link-sutil` e `.fat-proj-link-futuro` adicionados a `main.css`

Decisão PO (2026-04-20): Opção B — Q1=B | Q2=Cockpit | Q3=manter aba + link sutil

## Subagentes

- **test-runner**: ✅ PASS — 690 testes (679 base + 11 novos `projecoesCartao.test.js`)
- **security-reviewer**: ✅ PASS (1 HIGH corrigido: `escHTML()` em `preencherSeletorCartao`; 1 MED pré-existente em `buscarProjecoesRange`; 2 LOW confirmados seguros)

## Como testar

- [ ] `npm test` — 690 testes passando
- [ ] `npm run build` — build limpo
- [ ] Abrir `fatura.html?tab=projecoes` → link "ver consolidado em Futuro →" visível
- [ ] Abrir `fluxo-caixa.html` → seção "Compromissos Comprometidos" aparece após forecast
- [ ] Navbar: clicar "Cockpit" → dropdown com Dashboard + Planejamento
- [ ] Navbar: "Planejamento" não aparece mais em "Futuro"
- [ ] Acessar `planejamento.html` → seção Cockpit aberta na navbar

## Checklist

- [x] Sem credenciais Firebase no diff
- [x] CHANGELOG.md atualizado (v3.37.0)
- [x] CSS usa variáveis de variables.css
- [x] chave_dedup intacta (não tocado)
- [x] mesFatura propagado (projecoesCartao.js usa mesFatura via buscarProjecoesRange)
- [x] grupoId presente em todas as queries Firestore
- [x] escHTML() em todo innerHTML com dados do usuário (fix HIGH-001 incluído)
- [x] onSnapshot: unsubscribes gerenciados pelo caller (projecoesCartao.js retorna array)

Closes #186