### PR TITLE
feat(despesas): NRF-NAV Fase 3 — ENH-005 + DS tokens + XSS hardening (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.38.0] - 2026-04-20
+
+### Modificado
+
+- **NRF-NAV Fase 3 Opção B — ENH-005 + Design System refinements (#189):** simplificação de `despesas.html` (ENH-005 absorvida de #158): removidos KPI carousel de portadores/responsáveis (`chips-responsavel`, `chips-compartilhadas`, `chip-meu-bolso`) e widget "Parcelamentos em Aberto" — o cabeçalho da página agora exibe apenas Total do Mês + Contagem de Registros, focando a tela em seu papel operacional de CRUD/listagem. Listener `ouvirParcelamentosAbertos` e funções `renderizarPainelParcelamentos`, `agruparParPorCompra`, `renderizarChipsResponsavel`, `renderizarChipsCompartilhadas` removidos de `despesas.js`; `_unsubProj` eliminado (zero memory leak). Parcelamentos acessíveis via seção Futuro → Projeções (PR #187).
+- **Design System tokens — substituição de cores hardcoded (RF-070):** `fluxo-caixa.html` legend dots migrados de hex hardcoded (`#2e7d32`, `#c62828`, `#9e9e9e`, `#1565c0`) para tokens `var(--color-income)`, `var(--color-expense)`, `var(--color-text-muted)`, `var(--color-info)`. `components.css` — shadow do `.btn-danger:hover` migrado de `rgba(239,68,68,0.28)` (cor pré-rebrand) para novo token `--shadow-danger` alinhado ao Warm Finance. `despesas.js` — fallback de cor de categoria migrado de `#6c757d` para `getComputedStyle` + `--color-text-muted`.
+- **Segurança (XSS hardening) — `despesas.js`:** `escHTML()` aplicado em: `onclick` com `d.id` (4 botões inline), `<option>` de responsáveis, responsáveis do filtro, categorias (nome+emoji+id) e contas (nome+emoji+id); `title` de badge de conta sanitizado.
+
+### Removido
+
+- `despesas.html`: KPI carousel (chips de portador/responsável + Meu Bolso), widget "Parcelamentos em Aberto", botão `btn-ver-parc-desp` (ENH-005 — issue #158 absorvida).
+
 ## [3.37.0] - 2026-04-20
 
 ### Adicionado

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.37.0",
+  "version": "3.38.0",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -475,7 +475,7 @@ body {
 .btn-danger:hover {
   background: var(--color-danger-text);
   border-color: var(--color-danger-text);
-  box-shadow: 0 4px 10px rgba(239,68,68,0.28);
+  box-shadow: var(--shadow-danger);
 }
 
 /* Success */

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -127,6 +127,7 @@
   --shadow-xl:  0 20px 48px rgba(31,31,28, 0.12), 0 8px 16px rgba(31,31,28, 0.06);
   --shadow-card: 0 1px 3px rgba(31,31,28,0.06), 0 4px 12px rgba(31,31,28,0.04);
   --shadow-card-hover: 0 8px 24px rgba(204,120,92, 0.12), 0 2px 8px rgba(31,31,28,0.06);
+  --shadow-danger: 0 4px 10px rgba(181,84,64,0.28);
 
   /* ── Raios de borda ──────────────────────────────────────── */
   --radius-sm:   6px;
@@ -268,5 +269,6 @@
     --shadow-xl:  0 20px 48px rgba(0,0,0, 0.40), 0 8px 16px rgba(0,0,0, 0.25);
     --shadow-card: 0 1px 3px rgba(0,0,0,0.20), 0 4px 12px rgba(0,0,0,0.15);
     --shadow-card-hover: 0 8px 24px rgba(212,137,106, 0.18), 0 2px 8px rgba(0,0,0,0.25);
+    --shadow-danger: 0 4px 10px rgba(212,118,92,0.22);
   }
 }

--- a/src/despesas.html
+++ b/src/despesas.html
@@ -106,8 +106,6 @@
       </div>
 
       <div style="display:flex;gap:.5rem;">
-        <!-- CT-009.5: botão de visibilidade do painel de parcelamentos -->
-        <button id="btn-ver-parc-desp" class="btn btn-outline" title="Ver parcelamentos em aberto">💳 Parcelas</button>
         <button id="btn-exportar-csv" class="btn btn-outline" title="Exportar CSV">📥 Exportar CSV</button>
         <button id="btn-nova-despesa" class="btn btn-primary">+ Nova Despesa</button>
       </div>
@@ -122,30 +120,6 @@
       <div class="desp-chip desp-chip-count">
         <span class="desp-chip-label">Registros</span>
         <span class="desp-chip-valor" id="chip-count">0</span>
-      </div>
-      <!-- NRF-001: chip "Meu Bolso" — minha parte das conjuntas + individuais -->
-      <div class="desp-chip desp-chip-meu-bolso" id="chip-meu-bolso" style="display:none;">
-        <span class="desp-chip-label">👤 Meu Bolso</span>
-        <span class="desp-chip-valor" id="chip-meu-bolso-valor">R$ 0,00</span>
-      </div>
-      <!-- RF-014: chips por responsável (preenchidos via JS) -->
-      <div id="chips-responsavel" style="display:contents;"></div>
-      <!-- NRF-001: chips de compartilhadas por usuário (preenchidos via JS) -->
-      <div id="chips-compartilhadas" style="display:contents;"></div>
-    </div>
-
-    <!-- ═══ RF-014: PARCELAMENTOS EM ABERTO ═══ -->
-    <div class="card parc-widget hidden" id="parc-widget">
-      <div class="parc-widget-header" id="parc-toggle" style="cursor:pointer;">
-        <span>💳 Parcelamentos em Aberto</span>
-        <div style="display:flex;align-items:center;gap:.75rem;">
-          <span class="parc-total-valor" id="parc-total-desp">R$ 0,00</span>
-          <span class="parc-toggle-icon">▾</span>
-        </div>
-      </div>
-      <div id="parc-body-desp" class="parc-body">
-        <!-- Linha por portador, expandível -->
-        <div id="parc-lista-desp"></div>
       </div>
     </div>
 

--- a/src/fluxo-caixa.html
+++ b/src/fluxo-caixa.html
@@ -135,10 +135,10 @@
         <div class="fc-chart-header">
           <span class="fc-chart-titulo">Evolução Mensal</span>
           <div class="fc-legenda">
-            <span class="fc-leg-item"><span class="fc-leg-dot" style="background:#2e7d32"></span>Receitas</span>
-            <span class="fc-leg-item"><span class="fc-leg-dot" style="background:#c62828"></span>Despesas</span>
-            <span class="fc-leg-item"><span class="fc-leg-dot" style="background:#9e9e9e;border:2px dashed #9e9e9e;background:transparent"></span>Orçado</span>
-            <span class="fc-leg-item"><span class="fc-leg-dot" style="background:#1565c0"></span>Saldo Acum.</span>
+            <span class="fc-leg-item"><span class="fc-leg-dot" style="background:var(--color-income)"></span>Receitas</span>
+            <span class="fc-leg-item"><span class="fc-leg-dot" style="background:var(--color-expense)"></span>Despesas</span>
+            <span class="fc-leg-item"><span class="fc-leg-dot" style="border:2px dashed var(--color-text-muted);background:transparent"></span>Orçado</span>
+            <span class="fc-leg-item"><span class="fc-leg-dot" style="background:var(--color-info)"></span>Saldo Acum.</span>
           </div>
         </div>
         <div class="fc-chart-wrapper">

--- a/src/js/pages/despesas.js
+++ b/src/js/pages/despesas.js
@@ -11,7 +11,7 @@
 
 import { onAuthChange, logout } from '../services/auth.js';
 import { buscarPerfil, buscarGrupo, atualizarDespesa } from '../services/database.js';
-import { ouvirCategorias, ouvirParcelamentosAbertos, ouvirContas } from '../services/database.js';
+import { ouvirCategorias, ouvirContas } from '../services/database.js';
 import {
   iniciarListenerDespesas,
   salvarDespesa,
@@ -20,6 +20,9 @@ import {
 import { formatarMoeda, formatarData, nomeMes, escHTML } from '../utils/formatters.js';
 import { dataHoje, isMovimentacaoReal } from '../utils/helpers.js';
 import { skeletonCards, emptyStateHTML, errorStateHTML } from '../utils/skeletons.js';
+
+const _COR_CAT_FALLBACK = getComputedStyle(document.documentElement)
+  .getPropertyValue('--color-text-muted').trim() || '#8B8A82';
 
 // ── Estado da página ──────────────────────────────────────────
 let _usuario    = null;
@@ -30,14 +33,12 @@ let _ano        = new Date().getFullYear();
 let _despesas   = [];
 let _categorias = [];
 let _catMap     = {};
-let _projecoes  = [];       // RF-014: parcelas futuras em aberto
 
 let _contas     = [];       // NRF-004: contas/bancos do grupo
 let _contaMap   = {};       // NRF-004: id → conta
 
-let _unsubDesp  = null;
-let _unsubCats  = null;
-let _unsubProj  = null;     // RF-014: listener de projeções
+let _unsubDesp   = null;
+let _unsubCats   = null;
 let _unsubContas = null;    // NRF-004: listener de contas
 let _idParaExcluir = null;
 
@@ -78,18 +79,8 @@ onAuthChange(async (user) => {
   configurarEventos();
   atualizarTituloMes();
   iniciarListeners();
-  iniciarListenerProjecoes();
   iniciarListenerContas(); // NRF-004
 });
-
-// ── Listener de Projeções (RF-014) ────────────────────────────
-function iniciarListenerProjecoes() {
-  if (_unsubProj) _unsubProj();
-  _unsubProj = ouvirParcelamentosAbertos(_grupoId, (projecoes) => {
-    _projecoes = projecoes;
-    renderizarPainelParcelamentos();
-  });
-}
 
 // ── NRF-004: Listener de Contas ───────────────────────────────
 function iniciarListenerContas() {
@@ -134,8 +125,6 @@ function iniciarListeners() {
       _despesas = despesas;
       atualizarChips();
       renderizarLista();
-      renderizarChipsResponsavel();
-      renderizarChipsCompartilhadas();
       preencherFiltroResponsavel();
       // Atalho ?editar=ID: abre modal com a despesa assim que dados chegam
       if (_atalhoAbrirEditar) {
@@ -152,144 +141,6 @@ function iniciarListeners() {
   }
 }
 
-// ── RF-014: Painel de Parcelamentos em Aberto ─────────────────
-function renderizarPainelParcelamentos() {
-  const widget = document.getElementById('parc-widget');
-  const lista  = document.getElementById('parc-lista-desp');
-  const total  = document.getElementById('parc-total-desp');
-  if (!widget || !lista || !total) return;
-
-  const hoje    = new Date();
-  const futuras = _projecoes.filter(p => {
-    const d = p.data?.toDate?.() ?? new Date(p.data);
-    return d > hoje;
-  });
-
-  if (!futuras.length) {
-    widget.classList.add('hidden');
-    return;
-  }
-
-  widget.classList.remove('hidden');
-
-  // Agrupa por responsável / portador
-  const porResp = {};
-  let totalGeral = 0;
-
-  futuras.forEach(p => {
-    const resp = p.responsavel || p.portador || '—';
-    const val  = p.valor ?? 0;
-    if (!porResp[resp]) porResp[resp] = { total: 0, items: [] };
-    porResp[resp].total += val;
-    porResp[resp].items.push(p);
-    totalGeral += val;
-  });
-
-  total.textContent = formatarMoeda(totalGeral);
-
-  // Renderiza linhas por responsável
-  lista.innerHTML = Object.entries(porResp).map(([resp, dados]) => {
-    const primeiroNome = resp.split(' ')[0];
-    return `
-    <div class="parc-resp-row">
-      <div class="parc-resp-header">
-        <span class="parc-resp-nome">👤 ${primeiroNome}</span>
-        <span class="parc-resp-total">${formatarMoeda(dados.total)}</span>
-      </div>
-      <div class="parc-resp-items">
-        ${agruparParPorCompra(dados.items)}
-      </div>
-    </div>`;
-  }).join('');
-}
-
-function agruparParPorCompra(items) {
-  // Agrupa pelo parcelamento_id para mostrar 1 linha por compra
-  const compras = {};
-  items.forEach(p => {
-    const id = p.parcelamento_id ?? p.descricao;
-    if (!compras[id]) compras[id] = { descricao: p.descricao, valor: p.valor, parcelas: [] };
-    compras[id].parcelas.push(p.parcela ?? '—');
-  });
-  return Object.values(compras).map(c => {
-    const qtd    = c.parcelas.length;
-    const total  = c.valor * qtd;
-    const parcs  = c.parcelas.slice(0, 3).join(', ') + (qtd > 3 ? '…' : '');
-    return `
-    <div class="parc-compra-item">
-      <span class="parc-compra-desc">${c.descricao}</span>
-      <span class="parc-compra-info">${qtd} parcela${qtd > 1 ? 's' : ''} (${parcs})</span>
-      <span class="parc-compra-valor">${formatarMoeda(total)}</span>
-    </div>`;
-  }).join('');
-}
-
-// ── NRF-001: Chips de despesas compartilhadas por usuário ────
-function renderizarChipsCompartilhadas() {
-  const container = document.getElementById('chips-compartilhadas');
-  if (!container) return;
-
-  const conjuntas = _despesas.filter(d => isMovimentacaoReal(d) && d.isConjunta);
-  if (!conjuntas.length) {
-    container.innerHTML = '';
-    return;
-  }
-
-  // Soma valorAlocado de conjuntas por membro do grupo
-  const porResp = {};
-  Object.values(_grupo?.nomesMembros ?? {}).forEach(m => {
-    const nome = m.split(' ')[0];
-    porResp[nome] = conjuntas.reduce((s, d) => s + (d.valorAlocado ?? (d.valor ?? 0) / 2), 0);
-  });
-
-  container.innerHTML = Object.entries(porResp).map(([nome, val]) => `
-    <div class="desp-chip desp-chip-compartilhada">
-      <span class="desp-chip-label">👫 ${nome}</span>
-      <span class="desp-chip-valor">${formatarMoeda(val)}</span>
-    </div>`
-  ).join('');
-}
-
-// ── RF-014: Chips por responsável ────────────────────────────
-function renderizarChipsResponsavel() {
-  const container = document.getElementById('chips-responsavel');
-  if (!container) return;
-
-  const porResp = {};
-  _despesas
-    .filter(isMovimentacaoReal)
-    .forEach(d => {
-      if (d.isConjunta) {
-        // Despesa conjunta 50/50: cada membro do grupo paga valorAlocado
-        const share = d.valorAlocado ?? (d.valor ?? 0) / 2;
-        Object.values(_grupo?.nomesMembros ?? {}).forEach(m => {
-          const nome = m.split(' ')[0];
-          if (!porResp[nome]) porResp[nome] = 0;
-          porResp[nome] += share;
-        });
-      } else {
-        const resp = d.responsavel || d.portador || '';
-        if (!resp) return;
-        const nome = resp.split(' ')[0];
-        if (!porResp[nome]) porResp[nome] = 0;
-        porResp[nome] += d.valor ?? 0;
-      }
-    });
-
-
-  if (!Object.keys(porResp).length) {
-    container.innerHTML = '';
-    return;
-  }
-
-  container.innerHTML = Object.entries(porResp).map(([nome, val]) => `
-    <div class="desp-chip desp-chip-resp">
-      <span class="desp-chip-label">💳 ${nome}</span>
-      <span class="desp-chip-valor">${formatarMoeda(val)}</span>
-    </div>`
-  ).join('');
-}
-
 // ── RF-014: Dropdown de responsável no modal ─────────────────
 function preencherDropdownResponsavel() {
   const sel = document.getElementById('despesa-responsavel');
@@ -297,7 +148,7 @@ function preencherDropdownResponsavel() {
 
   const nomes = Object.values(_grupo.nomesMembros ?? {});
   sel.innerHTML = '<option value="">Selecione o responsável</option>' +
-    nomes.map(n => `<option value="${n}">${n}</option>`).join('');
+    nomes.map(n => `<option value="${escHTML(n)}">${escHTML(n)}</option>`).join('');
 }
 
 // ── RF-014: Filtro por responsável ──────────────────────────
@@ -315,7 +166,7 @@ function preencherFiltroResponsavel() {
   )].sort();
 
   sel.innerHTML = '<option value="">Todos os responsáveis</option>' +
-    responsaveis.map(r => `<option value="${r}">${r}</option>`).join('');
+    responsaveis.map(r => `<option value="${escHTML(r)}">${escHTML(r)}</option>`).join('');
   if (atual) sel.value = atual;
 }
 
@@ -350,8 +201,8 @@ function renderizarLista() {
     const cat      = _catMap[d.categoriaId];
     const emoji    = cat?.emoji ?? '❓';
     const nome     = cat?.nome  ?? '—';
-    const cor      = cat?.cor   ?? '#6c757d';
-    const badge    = `<span class="desp-cat-badge" style="background:${cor}22;color:${cor};">${emoji} ${nome}</span>`;
+    const cor      = cat?.cor   ?? _COR_CAT_FALLBACK;
+    const badge    = `<span class="desp-cat-badge" style="background:${cor}22;color:${cor};">${escHTML(emoji)} ${escHTML(nome)}</span>`;
     const dataFmt  = formatarData(d.data);
     const isProj   = d.tipo === 'projecao';
 
@@ -370,7 +221,7 @@ function renderizarLista() {
     // NRF-004: badge conta/banco
     const conta = _contaMap[d.contaId];
     const contaBadge = conta
-      ? `<span class="desp-conta-badge" style="background:${conta.cor}18;color:${conta.cor};border-color:${conta.cor}44;" title="${conta.nome}">${conta.emoji} ${conta.nome}</span>`
+      ? `<span class="desp-conta-badge" style="background:${conta.cor}18;color:${conta.cor};border-color:${conta.cor}44;" title="${escHTML(conta.nome)}">${escHTML(conta.emoji)} ${escHTML(conta.nome)}</span>`
       : '';
     // NRF-001: badge conjunta
     const conjuntaBadge = d.isConjunta
@@ -413,21 +264,21 @@ function renderizarLista() {
         <div class="desp-item-acoes">
           <button
             class="btn btn-sm btn-outline"
-            onclick="window._despEditar('${d.id}')"
+            onclick="window._despEditar('${escHTML(d.id)}')"
             title="Editar"
           >✏️</button>
           ${!isTransf ? `<button
             class="btn btn-sm btn-outline"
-            onclick="window._despMarcarTransferencia('${d.id}')"
+            onclick="window._despMarcarTransferencia('${escHTML(d.id)}')"
             title="Marcar como transferência interna"
           >🔁</button>` : `<button
             class="btn btn-sm btn-outline"
-            onclick="window._despDesmarcarTransferencia('${d.id}')"
+            onclick="window._despDesmarcarTransferencia('${escHTML(d.id)}')"
             title="Desmarcar transferência interna"
           >↩️</button>`}
           <button
             class="btn btn-sm btn-danger"
-            onclick="window._despExcluir('${d.id}','${d.descricao.replace(/'/g, "\\'")}')"
+            onclick="window._despExcluir('${escHTML(d.id)}','${escHTML(d.descricao).replace(/'/g, "\\'")}')"
             title="Excluir"
           >🗑️</button>
         </div>
@@ -445,22 +296,6 @@ function atualizarChips() {
   const chipCount = document.getElementById('chip-count');
   if (chipTotal) chipTotal.textContent = formatarMoeda(total);
   if (chipCount) chipCount.textContent = count;
-
-  // NRF-001: "Meu Bolso" = minhas individuais + valorAlocado das conjuntas (fix convidado)
-  const nomeUsuarioAtual = (_grupo?.nomesMembros?.[_usuario?.uid] ?? '').trim();
-  const meuBolso = reais.reduce((s, d) => {
-    if (d.isConjunta) return s + (d.valorAlocado ?? d.valor / 2);
-    const resp = (d.responsavel || d.portador || '').trim();
-    if (nomeUsuarioAtual && resp === nomeUsuarioAtual) return s + d.valor;
-    return s;
-  }, 0);
-  const chipMB    = document.getElementById('chip-meu-bolso');
-  const chipMBVal = document.getElementById('chip-meu-bolso-valor');
-  if (chipMB && chipMBVal) {
-    const hasConjunta = reais.some(d => d.isConjunta);
-    chipMB.style.display = hasConjunta ? '' : 'none';
-    chipMBVal.textContent = formatarMoeda(meuBolso);
-  }
 }
 
 function atualizarTituloMes() {
@@ -488,7 +323,7 @@ function preencherSelectCategorias(cats) {
   if (!sel) return;
   const atual = sel.value;
   sel.innerHTML = '<option value="">Selecione uma categoria</option>' +
-    cats.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
+    cats.map(c => `<option value="${escHTML(c.id)}">${escHTML(c.emoji)} ${escHTML(c.nome)}</option>`).join('');
   if (atual) sel.value = atual;
 }
 
@@ -497,7 +332,7 @@ function preencherFiltroCategorias(cats) {
   if (!sel) return;
   const atual = sel.value;
   sel.innerHTML = '<option value="">Todas as categorias</option>' +
-    cats.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
+    cats.map(c => `<option value="${escHTML(c.id)}">${escHTML(c.emoji)} ${escHTML(c.nome)}</option>`).join('');
   if (atual) sel.value = atual;
 }
 
@@ -507,7 +342,7 @@ function preencherSelectContas(contas) {
   if (!sel) return;
   const atual = sel.value;
   sel.innerHTML = '<option value="">Selecione a conta (opcional)</option>' +
-    contas.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
+    contas.map(c => `<option value="${escHTML(c.id)}">${escHTML(c.emoji)} ${escHTML(c.nome)}</option>`).join('');
   if (atual) sel.value = atual;
 }
 
@@ -516,7 +351,7 @@ function preencherFiltroContas(contas) {
   if (!sel) return;
   const atual = sel.value;
   sel.innerHTML = '<option value="">Todas as contas</option>' +
-    contas.map(c => `<option value="${c.id}">${c.emoji} ${c.nome}</option>`).join('');
+    contas.map(c => `<option value="${escHTML(c.id)}">${escHTML(c.emoji)} ${escHTML(c.nome)}</option>`).join('');
   if (atual) sel.value = atual;
 }
 
@@ -734,36 +569,6 @@ function configurarEventos() {
 
   // Exportar CSV
   document.getElementById('btn-exportar-csv')?.addEventListener('click', () => exportarCSV());
-
-  // RF-014: toggle painel parcelamentos (header interno)
-  document.getElementById('parc-toggle')?.addEventListener('click', () => {
-    const body = document.getElementById('parc-body-desp');
-    if (body) body.classList.toggle('parc-body--collapsed');
-    const icon = document.querySelector('#parc-toggle .parc-toggle-icon');
-    if (icon) icon.textContent = body?.classList.contains('parc-body--collapsed') ? '▸' : '▾';
-  });
-
-  // CT-009.5: botão externo de visibilidade do painel de parcelamentos
-  document.getElementById('btn-ver-parc-desp')?.addEventListener('click', () => {
-    const widget = document.getElementById('parc-widget');
-    if (!widget) return;
-    if (widget.classList.contains('hidden')) {
-      widget.classList.remove('hidden');
-      // Expande o body caso esteja colapsado
-      const body = document.getElementById('parc-body-desp');
-      if (body) body.classList.remove('parc-body--collapsed');
-      const icon = document.querySelector('#parc-toggle .parc-toggle-icon');
-      if (icon) icon.textContent = '▾';
-      // Mostra empty-state se não houver lista
-      const lista = document.getElementById('parc-lista-desp');
-      if (lista && !lista.querySelector('.parc-resp-row')) {
-        lista.innerHTML = '<p class="empty-state" style="font-size:.85rem;padding:.5rem 0;">Nenhum parcelamento em aberto no momento.</p>';
-      }
-    } else {
-      widget.classList.add('hidden');
-    }
-    widget.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  });
 }
 
 // ── Exportação CSV ────────────────────────────────────────────


### PR DESCRIPTION
## O que foi feito

### Parte 1 — ENH-005 (#158 absorvida)
- Removidos de `despesas.html`: KPI carousel (chips responsável, compartilhadas, Meu Bolso) e widget "Parcelamentos em Aberto"
- Cabeçalho da página agora exibe apenas **Total do Mês + Contagem de Registros** — papel operacional de CRUD/listagem
- Botão `btn-ver-parc-desp` removido do header
- Parcelamentos acessíveis via seção Futuro → Projeções (PR #187)
- `despesas.js`: removidos `ouvirParcelamentosAbertos`, `_unsubProj`, `renderizarPainelParcelamentos`, `agruparParPorCompra`, `renderizarChipsResponsavel`, `renderizarChipsCompartilhadas` — zero memory leak

### Parte 2 — Design System tokens (RF-070)
- `fluxo-caixa.html`: 4 legend dots migrados de hex hardcoded para `var(--color-income)`, `var(--color-expense)`, `var(--color-text-muted)`, `var(--color-info)`
- `components.css`: shadow `.btn-danger:hover` migrado de `rgba(239,68,68,0.28)` (cor pré-rebrand) para novo token `--shadow-danger` alinhado ao Warm Finance (#B55440)
- `variables.css`: adicionado `--shadow-danger` com variante light e dark
- `despesas.js`: fallback cor categoria migrado de `#6c757d` para `getComputedStyle` + `--color-text-muted`

### Parte 3 — XSS Hardening (security-reviewer FAIL → PASS)
- `escHTML()` aplicado em atributos `onclick` com `d.id` (4 botões inline)
- `escHTML()` em `<option>` de responsáveis, filtro responsável, categorias (nome+emoji+id) e contas (nome+emoji+id)
- `escHTML()` no atributo `title` do badge de conta

## Subagentes
- **test-runner**: PASS — 698 testes, build limpo
- **security-reviewer**: 3 FAILs identificados e corrigidos neste PR (Medium: d.id em onclick; Low: option sem escHTML; Very Low: title sem escHTML)
- **import-pipeline-reviewer**: N/A

## Como testar
- [ ] `npm test` — 698 testes verdes
- [ ] `npm run build` — sem erros
- [ ] `despesas.html` abre sem KPI carousel e sem widget Parcelamentos
- [ ] Total do mês e contagem de registros continuam corretos
- [ ] Parcelamentos acessíveis via Futuro → Projeções na navbar
- [ ] `fluxo-caixa.html` legend dots com cores do tema (dark mode funciona)
- [ ] `.btn-danger:hover` shadow visualmente correto

## Checklist
- [x] Sem credenciais Firebase no diff
- [x] CHANGELOG.md atualizado (v3.38.0)
- [x] CSS usa variáveis de variables.css
- [x] chave_dedup intacta (não tocada)
- [x] mesFatura não alterado (não tocado)
- [x] grupoId presente em todas as queries Firestore
- [x] escHTML() em todo innerHTML com dados do usuário
- [x] onSnapshot: unsubscribe guardado (_unsubProj removido junto com o listener)
- [x] Closes #189
- [x] Menção: #158 (ENH-005) absorvida e concluída neste PR