### PR TITLE
feat(design-system): NRF-UX F7 — Chart.js tokens + tabular-nums (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.39.6] - 2026-04-22
+
+### Adicionado
+
+- **NRF-UX F7 — Chart.js tokens + tabular-nums (#199):** tipografia dos gráficos migrada para tokens CSS; `font-variant-numeric: tabular-nums` aplicado em todas as classes de valores monetários.
+  - `src/css/variables.css`: token `--fw-chart: 500` adicionado à seção KPI/gráficos.
+  - `src/js/utils/chartDefaults.js`: `aplicarDefaultsControllerCharts()` reescrita para ler `--font-size-chart-tick` (13px), `--font-size-chart-legend` (14px), `--font-size-chart-tooltip` (14px), `--font-family` e `--fw-chart` via `getComputedStyle` — elimina `font.size = 14` hardcoded; guarda `typeof getComputedStyle === 'undefined'` para compatibilidade com ambiente Node.js.
+  - `src/css/main.css`: `tabular-nums` adicionado em `.orc-chip-valor`, `.desp-chip-valor`, `.desp-item-valor`/`.despesa-valor`, `.imp-chip-valor`, `.parc-total-valor`, `.parc-compra-valor`, `.rec-item-valor`, `.fat-card-valor`.
+  - `src/css/dashboard.css`: `tabular-nums` adicionado em `.parc-total-valor` e `.parc-compra-valor`.
+  - `src/css/planejamento.css`: `tabular-nums` adicionado em `.plan-kpi-valor`.
+  - `tests/utils/chartDefaults.test.js`: testes atualizados para mockar `getComputedStyle` e testar comportamento token-driven; 3 novos TCs (total: 756).
+
 ## [3.39.5] - 2026-04-22
 
 ### Adicionado

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.39.5",
+  "version": "3.39.6",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/src/css/dashboard.css
+++ b/src/css/dashboard.css
@@ -423,6 +423,7 @@
   font-weight: 800;
   color: var(--color-primary);
   letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
 }
 
 .parc-toggle-icon {
@@ -464,7 +465,7 @@
 }
 .parc-compra-desc  { flex: 1; color: var(--color-text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .parc-compra-info  { color: var(--color-text-muted); white-space: nowrap; }
-.parc-compra-valor { font-weight: 700; color: var(--color-text); white-space: nowrap; }
+.parc-compra-valor { font-weight: 700; color: var(--color-text); white-space: nowrap; font-variant-numeric: tabular-nums; }
 
 /* ══════════════════════════════════════════════════════════════
    RF-017: GRÁFICOS DO DASHBOARD

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -181,7 +181,7 @@ a:hover { text-decoration: underline; }
 .orc-resumo-chips { display: flex; gap: var(--space-3); flex-wrap: wrap; }
 .orc-chip { display: flex; flex-direction: column; align-items: center; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-2) var(--space-3); min-width: 100px; }
 .orc-chip-label { font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-text-muted); }
-.orc-chip-valor { font-size: var(--font-size-base); font-weight: 700; color: var(--color-text); }
+.orc-chip-valor { font-size: var(--font-size-base); font-weight: 700; color: var(--color-text); font-variant-numeric: tabular-nums; }
 .orc-chip-orcado  { border-top: 3px solid var(--color-primary); }
 .orc-chip-gasto   { border-top: 3px solid var(--color-warning); }
 .orc-chip-disponivel { border-top: 3px solid var(--color-ok); }
@@ -233,7 +233,7 @@ a:hover { text-decoration: underline; }
 .desp-chip { display: flex; flex-direction: column; align-items: center; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-2) var(--space-5); min-width: 8rem; transition: border-color var(--transition); }
 .desp-chip:hover { border-color: var(--color-border-hover); }
 .desp-chip-label { font-size: var(--font-size-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: .04em; }
-.desp-chip-valor { font-size: var(--font-size-lg); font-weight: 700; color: var(--color-text); margin-top: var(--space-0-5); }
+.desp-chip-valor { font-size: var(--font-size-lg); font-weight: 700; color: var(--color-text); margin-top: var(--space-0-5); font-variant-numeric: tabular-nums; }
 .desp-filtros { display: flex; gap: var(--space-3); flex-wrap: wrap; margin-bottom: var(--space-5); }
 .desp-filtros .select-input, .desp-filtros .input-field { flex: 1; min-width: 160px; }
 .desp-lista { display: flex; flex-direction: column; gap: var(--space-2); }
@@ -244,7 +244,7 @@ a:hover { text-decoration: underline; }
 .desp-item-descricao, .despesa-descricao { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .desp-item-data, .despesa-data, .despesa-meta { font-size: var(--font-size-xs); color: var(--color-text-muted); white-space: nowrap; }
 .desp-item-right { display: flex; align-items: center; gap: var(--space-3); flex-shrink: 0; }
-.desp-item-valor, .despesa-valor { font-weight: 700; font-size: var(--font-size-md); color: var(--color-danger); white-space: nowrap; }
+.desp-item-valor, .despesa-valor { font-weight: 700; font-size: var(--font-size-md); color: var(--color-danger); white-space: nowrap; font-variant-numeric: tabular-nums; }
 .desp-item-acoes, .despesa-acoes { display: flex; gap: var(--space-1); }
 .despesa-item { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) var(--space-4); flex-wrap: wrap; }
 .despesa-left { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; flex: 1; min-width: 0; }
@@ -287,7 +287,7 @@ a:hover { text-decoration: underline; }
 .imp-chip--azul   { border-color: var(--color-balance-border); background: var(--color-info-light); }
 .imp-chip--aviso  { border-color: var(--color-fuzzy-border); background: var(--color-warning-light); }
 .imp-chip-label   { display: block; font-size: var(--font-size-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: .04em; }
-.imp-chip-valor   { display: block; font-size: var(--font-size-lg); font-weight: 700; }
+.imp-chip-valor   { display: block; font-size: var(--font-size-lg); font-weight: 700; font-variant-numeric: tabular-nums; }
 .imp-acoes-lote { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-3); }
 .imp-label-cat-lote { font-size: var(--font-size-sm); color: var(--color-text-muted); white-space: nowrap; }
 .imp-sel-lote { font-size: var(--font-size-sm); padding: var(--space-1) var(--space-2); max-width: 180px; }
@@ -337,7 +337,7 @@ a:hover { text-decoration: underline; }
 .rec-item--transf { opacity: .75; border-left: var(--space-0-75) solid var(--color-info-border) !important; background: var(--color-info-bg) !important; }
 .parc-widget { margin-bottom: var(--space-5); border: 1px solid var(--color-info-border); background: var(--color-info-bg); }
 .parc-widget-header { display: flex; align-items: center; justify-content: space-between; padding: var(--space-3) var(--space-5); font-weight: 600; font-size: var(--font-size-base); color: var(--color-info-text); user-select: none; }
-.parc-total-valor { font-size: var(--font-size-lg); font-weight: 700; color: var(--color-info-text); }
+.parc-total-valor { font-size: var(--font-size-lg); font-weight: 700; color: var(--color-info-text); font-variant-numeric: tabular-nums; }
 .parc-toggle-icon { font-size: var(--font-size-sm); color: var(--color-info-text); transition: transform var(--transition); }
 .parc-body { padding: 0 var(--space-5) var(--space-4); border-top: 1px solid var(--color-info-border); overflow: hidden; transition: max-height var(--transition-slow); }
 .parc-body--collapsed { display: none; }
@@ -350,7 +350,7 @@ a:hover { text-decoration: underline; }
 .parc-compra-item:last-child { border-bottom: none; }
 .parc-compra-desc { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--color-text); max-width: 55%; }
 .parc-compra-info { color: var(--color-text-muted); font-size: var(--font-size-sm); white-space: nowrap; }
-.parc-compra-valor { font-weight: 700; color: var(--color-info-text); white-space: nowrap; min-width: 80px; text-align: right; }
+.parc-compra-valor { font-weight: 700; color: var(--color-info-text); white-space: nowrap; min-width: 80px; text-align: right; font-variant-numeric: tabular-nums; }
 .imp-chip--dup  { background: var(--color-fuzzy-bg); border-color: var(--color-fuzzy-border); }
 .imp-chip--dup  .imp-chip-label, .imp-chip--dup  .imp-chip-valor { color: var(--color-fuzzy-text); }
 .imp-chip--proj { background: var(--color-conjunta-light); border-color: var(--color-conjunta-border); }
@@ -676,7 +676,7 @@ a:hover { text-decoration: underline; }
 .rec-item-info  { flex: 1; min-width: 0; }
 .rec-item-desc  { font-weight: 600; font-size: var(--font-size-sm); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .rec-item-meta  { font-size: var(--font-size-xs); color: var(--color-text-muted); }
-.rec-item-valor { font-weight: 700; color: var(--color-income-dark); white-space: nowrap; }
+.rec-item-valor { font-weight: 700; color: var(--color-income-dark); white-space: nowrap; font-variant-numeric: tabular-nums; }
 .rec-item-acoes { display: flex; gap: var(--space-1); }
 
 /* ══════════════════════════════════════════════════════════════
@@ -876,7 +876,7 @@ a:hover { text-decoration: underline; }
 .fat-card--membro { border: 1.5px solid var(--color-border); }
 .fat-card-label { font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: .04em; opacity: .75; }
 .fat-card--total .fat-card-label { color: var(--color-text-inverse-muted); }
-.fat-card-valor { font-size: var(--font-size-xl); font-weight: 800; margin: var(--space-1) 0 var(--space-0-5); }
+.fat-card-valor { font-size: var(--font-size-xl); font-weight: 800; margin: var(--space-1) 0 var(--space-0-5); font-variant-numeric: tabular-nums; }
 .fat-card--total .fat-card-valor { color: var(--color-text-inverse); }
 .fat-card-sub { font-size: var(--font-size-xs); opacity: .7; }
 

--- a/src/css/planejamento.css
+++ b/src/css/planejamento.css
@@ -61,6 +61,7 @@
 .plan-kpi-valor {
   font-size: var(--font-size-xl);
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 .plan-kpi--positivo .plan-kpi-valor { color: var(--color-ok); }

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -159,13 +159,14 @@
   --line-height-normal:  1.5;
   --line-height-relaxed: 1.65;
 
-  /* ── KPI e gráficos (NRF-VISUAL F1 #192) ────────────────────── */
+  /* ── KPI e gráficos (NRF-VISUAL F1 #192 / NRF-UX F7 #199) ─── */
   --font-size-kpi:            28px;
   --font-size-kpi-hero:       40px;
   --font-size-chart-tick:     13px;
   --font-size-chart-legend:   14px;
   --font-size-chart-title:    13px;
   --font-size-chart-tooltip:  14px;
+  --fw-chart:                 500;
 
   /* ── Espaçamento ─────────────────────────────────────────── */
   --space-0-5:  2px;

--- a/src/js/utils/chartDefaults.js
+++ b/src/js/utils/chartDefaults.js
@@ -1,12 +1,32 @@
 // ============================================================
-// chartDefaults — aplica tipografia Controller nos gráficos
-// NRF-VISUAL F1 (#192): tamanhos alinhados aos tokens CSS
+// chartDefaults — aplica tipografia nos gráficos Chart.js
+// NRF-UX F7 (#199): lê tokens CSS em vez de valores fixos
 // ============================================================
+
+const _css = (prop) => {
+  if (typeof getComputedStyle === 'undefined' || typeof document === 'undefined') return '';
+  return getComputedStyle(document.documentElement).getPropertyValue(prop).trim();
+};
+
+const _px = (val, fallback) => {
+  const n = parseInt(val, 10);
+  return Number.isFinite(n) ? n : fallback;
+};
 
 export function aplicarDefaultsControllerCharts() {
   if (typeof Chart === 'undefined') return;
-  Chart.defaults.font.size = 14;
-  Chart.defaults.plugins.tooltip.bodyFont  = { size: 14 };
-  Chart.defaults.plugins.tooltip.titleFont = { size: 14 };
-  Chart.defaults.plugins.legend.labels.font = { size: 14 };
+
+  const family = _css('--font-family') || "'Inter', sans-serif";
+  const weight = _css('--fw-chart')    || '500';
+  const tick    = _px(_css('--font-size-chart-tick'),    13);
+  const legend  = _px(_css('--font-size-chart-legend'),  14);
+  const tooltip = _px(_css('--font-size-chart-tooltip'), 14);
+
+  Chart.defaults.font.size   = tick;
+  Chart.defaults.font.family = family;
+  Chart.defaults.font.weight = weight;
+
+  Chart.defaults.plugins.tooltip.bodyFont  = { size: tooltip, family, weight };
+  Chart.defaults.plugins.tooltip.titleFont = { size: tooltip, family, weight: '600' };
+  Chart.defaults.plugins.legend.labels.font = { size: legend, family, weight };
 }

--- a/tests/utils/chartDefaults.test.js
+++ b/tests/utils/chartDefaults.test.js
@@ -1,41 +1,92 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { aplicarDefaultsControllerCharts } from '../../src/js/utils/chartDefaults.js';
 
-describe('chartDefaults', () => {
-  afterEach(() => {
-    delete globalThis.Chart;
+const TOKEN_MAP = {
+  '--font-size-chart-tick':    '13px',
+  '--font-size-chart-legend':  '14px',
+  '--font-size-chart-tooltip': '14px',
+  '--font-family':             "'Inter', sans-serif",
+  '--fw-chart':                '500',
+};
+
+function mockBrowserGlobals() {
+  globalThis.document = { documentElement: {} };
+  globalThis.getComputedStyle = () => ({
+    getPropertyValue: (prop) => TOKEN_MAP[prop] ?? '',
   });
+}
+
+function cleanupBrowserGlobals() {
+  delete globalThis.document;
+  delete globalThis.getComputedStyle;
+  delete globalThis.Chart;
+}
+
+function makeChart() {
+  return { defaults: { font: {}, plugins: { tooltip: {}, legend: { labels: {} } } } };
+}
+
+describe('chartDefaults', () => {
+  beforeEach(mockBrowserGlobals);
+  afterEach(cleanupBrowserGlobals);
 
   it('não lança erro quando Chart não está disponível', () => {
     expect(() => aplicarDefaultsControllerCharts()).not.toThrow();
   });
 
-  it('configura font.size global para 14', () => {
-    globalThis.Chart = { defaults: { font: {}, plugins: { tooltip: {}, legend: { labels: {} } } } };
-    aplicarDefaultsControllerCharts();
-    expect(globalThis.Chart.defaults.font.size).toBe(14);
-  });
-
-  it('configura tooltip bodyFont para size 14', () => {
-    globalThis.Chart = { defaults: { font: {}, plugins: { tooltip: {}, legend: { labels: {} } } } };
-    aplicarDefaultsControllerCharts();
-    expect(globalThis.Chart.defaults.plugins.tooltip.bodyFont).toEqual({ size: 14 });
-  });
-
-  it('configura tooltip titleFont para size 14', () => {
-    globalThis.Chart = { defaults: { font: {}, plugins: { tooltip: {}, legend: { labels: {} } } } };
-    aplicarDefaultsControllerCharts();
-    expect(globalThis.Chart.defaults.plugins.tooltip.titleFont).toEqual({ size: 14 });
-  });
-
-  it('configura legend labels font para size 14', () => {
-    globalThis.Chart = { defaults: { font: {}, plugins: { tooltip: {}, legend: { labels: {} } } } };
-    aplicarDefaultsControllerCharts();
-    expect(globalThis.Chart.defaults.plugins.legend.labels.font).toEqual({ size: 14 });
-  });
-
   it('não altera Chart quando Chart é undefined explícito', () => {
     globalThis.Chart = undefined;
     expect(() => aplicarDefaultsControllerCharts()).not.toThrow();
+  });
+
+  it('configura font.size via token --font-size-chart-tick (13px)', () => {
+    globalThis.Chart = makeChart();
+    aplicarDefaultsControllerCharts();
+    expect(globalThis.Chart.defaults.font.size).toBe(13);
+  });
+
+  it('configura font.family via token --font-family', () => {
+    globalThis.Chart = makeChart();
+    aplicarDefaultsControllerCharts();
+    expect(globalThis.Chart.defaults.font.family).toBe("'Inter', sans-serif");
+  });
+
+  it('configura font.weight via token --fw-chart', () => {
+    globalThis.Chart = makeChart();
+    aplicarDefaultsControllerCharts();
+    expect(globalThis.Chart.defaults.font.weight).toBe('500');
+  });
+
+  it('configura tooltip bodyFont via tokens', () => {
+    globalThis.Chart = makeChart();
+    aplicarDefaultsControllerCharts();
+    expect(globalThis.Chart.defaults.plugins.tooltip.bodyFont).toEqual({
+      size: 14, family: "'Inter', sans-serif", weight: '500',
+    });
+  });
+
+  it('configura tooltip titleFont com weight 600', () => {
+    globalThis.Chart = makeChart();
+    aplicarDefaultsControllerCharts();
+    expect(globalThis.Chart.defaults.plugins.tooltip.titleFont).toEqual({
+      size: 14, family: "'Inter', sans-serif", weight: '600',
+    });
+  });
+
+  it('configura legend labels font via tokens', () => {
+    globalThis.Chart = makeChart();
+    aplicarDefaultsControllerCharts();
+    expect(globalThis.Chart.defaults.plugins.legend.labels.font).toEqual({
+      size: 14, family: "'Inter', sans-serif", weight: '500',
+    });
+  });
+
+  it('usa fallbacks quando tokens CSS retornam vazio', () => {
+    globalThis.getComputedStyle = () => ({ getPropertyValue: () => '' });
+    globalThis.Chart = makeChart();
+    aplicarDefaultsControllerCharts();
+    expect(globalThis.Chart.defaults.font.size).toBe(13);
+    expect(globalThis.Chart.defaults.font.family).toBe("'Inter', sans-serif");
+    expect(globalThis.Chart.defaults.font.weight).toBe('500');
   });
 });


### PR DESCRIPTION
## Resumo

- `chartDefaults.js` agora lê tokens CSS (`--font-size-chart-tick`, `--font-size-chart-legend`, `--font-size-chart-tooltip`, `--font-family`, `--fw-chart`) via `getComputedStyle` em vez de hardcodar `14px`
- Novo token `--fw-chart: 500` em `variables.css`
- `font-variant-numeric: tabular-nums` aplicado em 9 novas classes de valores monetários (`.orc-chip-valor`, `.desp-chip-valor`, `.desp-item-valor`, `.imp-chip-valor`, `.parc-total-valor`, `.parc-compra-valor`, `.rec-item-valor`, `.fat-card-valor`, `.plan-kpi-valor`)
- Testes de `chartDefaults` atualizados para mockar `getComputedStyle` — 756 TCs, todos passando

## Subagentes

- **test-runner:** ✅ 756/756 PASS
- **ux-reviewer:** ✅ APPROVED — PUX1-PUX6 todos PASS; 3 gaps LOW pré-existentes documentados para cleanup separado

## Issues relacionadas

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)