### PR TITLE
fix(design-system): add tabular-nums to remaining monetary value classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
   - `src/css/planejamento.css`: `tabular-nums` adicionado em `.plan-kpi-valor`.
   - `tests/utils/chartDefaults.test.js`: testes atualizados para mockar `getComputedStyle` e testar comportamento token-driven; 3 novos TCs (total: 756).
 
+### Corrigido
+
+- **fix(design-system): tabular-nums em classes monetárias remanescentes** — 3 gaps pré-existentes identificados pelo ux-reviewer durante NRF-UX F7 (#199):
+  - `src/css/main.css`: `.rec-cat-valor` — `tabular-nums` + migração de `0.875rem` hardcoded → `var(--font-size-sm)`; `.fat-footer-valor` — `tabular-nums`.
+  - `src/css/planejamento.css`: `.plan-valor-previsto` e `.plan-valor-realizado` — `tabular-nums`.
+
 ## [3.39.5] - 2026-04-22
 
 ### Adicionado

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -651,8 +651,9 @@ a:hover { text-decoration: underline; }
 
 /* Valor da categoria de receita */
 .rec-cat-valor {
-  font-size: .875rem;
+  font-size: var(--font-size-sm);
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Card de categoria receita — override de cores */
@@ -928,7 +929,7 @@ a:hover { text-decoration: underline; }
 /* Seção footer de conjuntas */
 .fat-section-footer { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-3) var(--space-4); background: var(--color-warning-light); border-top: 1px solid var(--color-warning); font-size: var(--font-size-sm); }
 .fat-footer-label { font-weight: 600; color: var(--color-text-secondary); }
-.fat-footer-valor { font-weight: 700; color: var(--color-text); }
+.fat-footer-valor { font-weight: 700; color: var(--color-text); font-variant-numeric: tabular-nums; }
 .fat-footer-sep { color: var(--color-text-muted); }
 .fat-footer-split { color: var(--color-info); }
 

--- a/src/css/planejamento.css
+++ b/src/css/planejamento.css
@@ -146,9 +146,9 @@
 
 /* ── Valores ──────────────────────────────────────────────── */
 
-.plan-valor-previsto { color: var(--color-text-muted); }
+.plan-valor-previsto { color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
 
-.plan-valor-realizado { font-weight: 600; }
+.plan-valor-realizado { font-weight: 600; font-variant-numeric: tabular-nums; }
 .plan-valor-realizado--ok    { color: var(--color-ok); }
 .plan-valor-realizado--acima { color: var(--color-danger); }
 .plan-valor-realizado--vazio { color: var(--color-text-muted); font-style: italic; }


### PR DESCRIPTION
## Resumo

Gaps pré-existentes identificados pelo ux-reviewer durante NRF-UX F7 (#199). Nenhuma regressão — apenas classes que ainda não tinham `tabular-nums`.

- `.rec-cat-valor` — `tabular-nums` + `0.875rem` hardcoded → `var(--font-size-sm)` (token correto)
- `.fat-footer-valor` — `tabular-nums` em total do rodapé da fatura
- `.plan-valor-previsto` + `.plan-valor-realizado` — `tabular-nums` em valores de planejamento

## Testes

753/753 PASS

## Notas de merge

Esta branch é baseada em `main` (v3.39.5). Se PR #206 (NRF-UX F7) for mesclado primeiro, versão nesta branch deverá ser rebumped para v3.39.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)