### PR TITLE
feat(design-system): NRF-UX F8 — Microcopy e vocabulário (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.39.7] - 2026-04-22
+
+### Adicionado
+
+- **NRF-UX F8 — Microcopy e vocabulário (#200):** guia de tom, padronização de mensagens e remoção de todos os `alert()` do app.
+  - `docs/MF_Microcopy.md`: guia completo de tom de voz, padrões de botões, empty states, validação, erros, sucesso, placeholders, glossário de 10 termos e 20 exemplos antes × depois.
+  - `src/receitas.html` / `src/js/pages/receitas.js`: validação de formulário migrada de `alert()` para elemento inline `#rec-modal-erro` via helper `_setErroModal()`; erro limpo ao fechar modal; empty state usa mês dinâmico (`Sem receitas em {mês}.`).
+  - `src/contas.html` / `src/js/pages/contas.js`: erros de save (saldo e cartão) migrados de `alert()` para `#saldo-modal-erro` / `#cartao-modal-erro`.
+  - `src/patrimonio.html` / `src/js/pages/patrimonio.js`: erros de save (investimento e passivo) → `#inv-modal-erro` / `#pass-modal-erro`; snapshot → `_feedbackSnapshot()` com feedback inline temporário (3s).
+  - `src/js/pages/base-dados.js`: `alert()` em excluir em massa e purge → `mostrarToast()` existente; texto corrigido de `❌ Erro ao atualizar` → `Não consegui atualizar`.
+  - `src/js/pages/fatura.js`, `importar.js`: guards de XLSX não carregado → `console.error` silencioso.
+  - `src/js/pages/despesas.js`: empty state usa mês dinâmico; erros de transferência interna → silenciosos (já logados).
+  - Empty states padronizados: `Sem receitas em {mês}.` / `Sem despesas em {mês}.` / `Nenhuma despesa para os filtros selecionados.` / `Nenhum cartão. Adicione o primeiro.`
+  - Mensagens de erro padronizadas: `Não consegui salvar…` em vez de `Erro ao salvar…`; `Não consegui excluir…`; `Não consegui purgar…`
+
 ## [3.39.6] - 2026-04-22
 
 ### Adicionado

--- a/docs/MF_Microcopy.md
+++ b/docs/MF_Microcopy.md
@@ -1,0 +1,179 @@
+# MF Microcopy — Guia de Tom e Vocabulário
+
+> NRF-UX F8 (#200) · v3.39.7 · 2026-04-22
+
+---
+
+## Tom de voz
+
+**Direto, curto, sem jargão bancário.** O app fala como um amigo organizado falaria com Luigi e Ana — não como um extrato de banco.
+
+| ✅ Preferir | ❌ Evitar |
+|---|---|
+| `Salvo` | `Operação realizada com sucesso` |
+| `Não consegui salvar` | `Erro inesperado ao processar sua solicitação` |
+| `Verifique sua conexão` | `Falha na comunicação com o servidor` |
+| `Sem despesas este mês` | `Nenhum registro encontrado para o período selecionado` |
+| `Adicione a primeira` | `Não há itens cadastrados` |
+
+**Conjugação:** imperativo em CTAs (`Salvar`, `Criar`, `Importar`). Segunda pessoa direta nos textos explicativos.
+
+**Comprimento:** mensagens de erro ≤ 2 linhas. CTAs ≤ 3 palavras.
+
+---
+
+## Botões — Padrão
+
+### Criar (ação primária)
+| Contexto | Label |
+|---|---|
+| Nova despesa | `+ Nova Despesa` |
+| Nova receita | `+ Nova Receita` |
+| Novo cartão | `+ Novo Cartão` |
+| Nova categoria | `+ Nova Categoria` |
+| Novo investimento | `+ Novo Investimento` |
+| Nova dívida | `+ Nova Dívida` |
+| Novo item de planejamento | `+ Adicionar Item` |
+
+### Salvar / Confirmar
+| Contexto | Label |
+|---|---|
+| Formulário geral | `Salvar` |
+| Saldo de conta | `Salvar Saldo` |
+| Ação destrutiva (confirmação) | `Excluir` ou `Confirmar` |
+
+### Navegação de período
+Usar `‹` e `›` como ícones isolados (sem texto). Adicionar `title="Mês anterior"` / `title="Próximo mês"` para acessibilidade.
+
+### Estados de carregamento
+Adicionar `…` ao label do botão: `Salvando…`, `Criando…`, `Excluindo…`, `Importando…`.
+
+---
+
+## Empty States — Padrão
+
+### Sem dados (verdadeiro)
+Estrutura: **mensagem curta** + **ação sugerida** (quando aplicável).
+
+| Tela | Mensagem | CTA sugerida |
+|---|---|---|
+| Despesas — lista vazia | `Sem despesas em {mês}. Adicione a primeira.` | `+ Nova Despesa` |
+| Receitas — lista vazia | `Sem receitas em {mês}.` | `+ Nova Receita` |
+| Categorias — lista vazia | `Nenhuma categoria ainda. Crie a primeira!` | `+ Nova Categoria` |
+| Fatura — sem transações | `Nenhuma transação neste período.` | — |
+| Base de dados — sem resultados de filtro | `Nenhuma transação para os filtros selecionados.` | — |
+| Orçamentos — sem categorias | `Adicione categorias para criar orçamentos.` | — |
+| Investimentos — lista vazia | `Nenhum investimento cadastrado.` | `+ Novo Investimento` |
+| Passivos — lista vazia | `Nenhuma dívida cadastrada.` | `+ Nova Dívida` |
+
+### Carregando (transitório)
+Usar skeletons (ver F5 — já implementado). Texto de fallback: `Carregando…`
+
+---
+
+## Validação de Formulários — Padrão
+
+**Regra:** nunca usar `alert()`. Exibir erro inline, próximo ao campo com problema.
+
+| Campo | Mensagem de erro |
+|---|---|
+| Descrição vazia | `Informe uma descrição.` |
+| Valor inválido / vazio | `Informe um valor válido.` |
+| Data ausente | `Informe a data.` |
+| Categoria não selecionada | `Selecione uma categoria.` |
+| Responsável não selecionado | `Selecione o responsável.` |
+
+**Formato:** frase curta, sem ponto de exclamação, com ponto final.
+
+---
+
+## Mensagens de Erro — Padrão
+
+### Operações de rede (salvar, excluir, carregar)
+Preferir mensagem específica ao contexto. Se não souber a causa: mencionar conexão.
+
+| Operação | Mensagem |
+|---|---|
+| Salvar despesa falhou | `Não consegui salvar a despesa. Verifique sua conexão.` |
+| Salvar receita falhou | `Não consegui salvar a receita. Verifique sua conexão.` |
+| Salvar cartão falhou | `Não consegui salvar o cartão. Tente novamente.` |
+| Excluir falhou | `Não consegui excluir. Tente novamente.` |
+| Carregar falhou | `Não consegui carregar os dados. Verifique sua conexão.` |
+| Operação genérica falhou | `Algo deu errado. Tente novamente.` |
+
+### Erros de importação
+| Situação | Mensagem |
+|---|---|
+| Arquivo não reconhecido | `Não reconheci este arquivo. Use CSV ou XLSX do banco.` |
+| Nenhuma transação encontrada | `Nenhuma transação encontrada no arquivo.` |
+| Algumas linhas com erro | `{n} linha{s} não puderam ser importadas.` |
+
+---
+
+## Mensagens de Sucesso — Padrão
+
+### Salvar / Criar
+Usar toast curto: sem ponto de exclamação, com ✅.
+
+| Operação | Toast |
+|---|---|
+| Despesa salva | `✅ Despesa salva` |
+| Receita salva | `✅ Receita salva` |
+| Categoria criada | `✅ Categoria criada` |
+| Cartão salvo | `✅ Cartão salvo` |
+| Saldo salvo | `✅ Saldo atualizado` |
+
+### Importação
+Manter o padrão atual de importar.js (detalhado é útil aqui — o usuário quer saber quantas linhas foram processadas).
+
+---
+
+## Placeholders — Padrão
+
+Sempre usar `Ex:` como prefixo quando o campo aceita formato livre.
+Campos numéricos: mostrar exemplo real (`Ex: 3.500,00`), não `0,00`.
+Campos de busca: `Buscar por descrição…` (com reticências).
+
+---
+
+## Glossário de Termos
+
+| Termo a usar | Sinônimos a evitar |
+|---|---|
+| Despesa | Gasto, Lançamento, Débito |
+| Receita | Entrada, Crédito |
+| Cartão | Cartão de crédito (exceto quando necessário diferenciar) |
+| Fatura | Extrato, Fechamento |
+| Parcelamento | Compra parcelada (só usar quando o contexto é novo parcelamento) |
+| Projeção | Parcela futura, Previsão |
+| Importar | Upload, Carregar arquivo |
+| Categoria | Tag, Label |
+| Grupo | Família (só usar para clareza contextual) |
+| Planejamento | Orçamento mensal (Planejamento = mês inteiro; Orçamento = por categoria) |
+
+---
+
+## 20 Exemplos de Antes × Depois
+
+| # | Antes | Depois | Tipo |
+|---|---|---|---|
+| 1 | `Operação realizada com sucesso` | `✅ Salvo` | Sucesso genérico |
+| 2 | `Nenhuma transação encontrada para os filtros selecionados.` | `Nenhuma transação para os filtros selecionados.` | Empty state filtro |
+| 3 | `Erro ao salvar saldo. Tente novamente.` | `Não consegui salvar o saldo. Tente novamente.` | Erro de rede |
+| 4 | `Nenhuma receita registrada neste mês.` | `Sem receitas em {mês}.` | Empty state |
+| 5 | `Nenhum cartão cadastrado. Clique em "+ Novo Cartão" para adicionar.` | `Nenhum cartão. Adicione o primeiro.` | Empty state |
+| 6 | `Erro ao carregar fatura. Verifique sua conexão e tente novamente.` | `Não consegui carregar a fatura. Verifique sua conexão.` | Erro de carregamento |
+| 7 | `Informe uma descrição.` (alert) | Erro inline abaixo do campo | Validação |
+| 8 | `Você está prestes a excluir {n} transação permanentemente.` | `Excluir {n} transação{ões} permanentemente?` | Confirmação destrutiva |
+| 9 | `Nenhuma categoria de despesa. Crie a primeira!` | `Nenhuma categoria ainda. Crie a primeira!` | Empty state |
+| 10 | `Confirmar tipo` | `Confirmar` | Botão (curtar) |
+| 11 | `Selecione um cartão para ver os dados de liquidação.` | `Selecione um cartão.` | Instrução de seleção |
+| 12 | `Erro ao excluir receita.` | `Não consegui excluir a receita.` | Erro de operação |
+| 13 | `SheetJS não carregado.` | `Não consegui gerar o template. Recarregue a página.` | Erro técnico traduzido |
+| 14 | `Selecione uma categoria` (sem ponto) | `Selecione uma categoria.` | Validação (consistência) |
+| 15 | `Sem meta definida` | `Sem meta` | Label curto |
+| 16 | `Sem limite definido` | `Sem limite` | Label curto |
+| 17 | `— selecione —` | `— selecione —` | Manter (padrão OK) |
+| 18 | `Buscar descrição...` | `Buscar por descrição…` | Placeholder (consistência, reticências tipográficas) |
+| 19 | `❌ Erro ao atualizar. Tente novamente.` | `Não consegui atualizar. Tente novamente.` | Erro toast (remover ❌) |
+| 20 | `Criando…` (botão loading) | `Criando…` | Manter (padrão OK) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.39.6",
+  "version": "3.39.7",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/src/contas.html
+++ b/src/contas.html
@@ -150,6 +150,7 @@
           <label for="inp-data-referencia">Data de referência *</label>
           <input id="inp-data-referencia" class="form-input" type="date" required />
         </div>
+        <p class="form-erro hidden" id="saldo-modal-erro"></p>
         <div class="modal-footer" style="margin-top:1rem;">
           <button type="button" id="btn-cancelar-saldo" class="btn btn-outline">Cancelar</button>
           <button type="submit" class="btn btn-primary">Salvar Saldo</button>
@@ -228,6 +229,7 @@
             <input id="inp-cartao-cor" type="color" value="#7B1FA2" style="height:2.5rem;border:none;cursor:pointer;" />
           </div>
         </div>
+        <p class="form-erro hidden" id="cartao-modal-erro"></p>
         <div class="modal-footer" style="margin-top:1.25rem;">
           <button type="button" id="btn-cancelar-cartao" class="btn btn-outline">Cancelar</button>
           <button type="submit" class="btn btn-primary">Salvar</button>

--- a/src/js/pages/base-dados.js
+++ b/src/js/pages/base-dados.js
@@ -565,7 +565,7 @@ async function confirmarExclusao() {
     aplicarFiltros();
   } catch (e) {
     console.error('Erro ao excluir em massa:', e);
-    alert('Erro ao excluir transações. Tente novamente.');
+    mostrarToast('Não consegui excluir. Tente novamente.', true);
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = 'Excluir permanentemente'; }
   }
@@ -600,7 +600,7 @@ async function confirmarAtualizacaoResp() {
     mostrarToast(`✅ ${n} transaç${n !== 1 ? 'ões' : 'ão'} atualizada${n !== 1 ? 's' : ''} — responsável: ${responsavel}`);
   } catch (e) {
     console.error('Erro ao atualizar responsável em massa:', e);
-    mostrarToast('❌ Erro ao atualizar. Tente novamente.', true);
+    mostrarToast('Não consegui atualizar. Tente novamente.', true);
   } finally {
     if (btnResp) { btnResp.disabled = false; btnResp.textContent = 'Aplicar'; }
   }
@@ -676,7 +676,7 @@ function configurarLimpeza() {
       renderizarPagina();
     } catch (e) {
       console.error('Erro no purge:', e);
-      alert('Erro ao purgar a base de dados. Tente novamente.');
+      mostrarToast('Não consegui purgar a base de dados. Tente novamente.', true);
     } finally {
       btnConf.disabled = false;
       btnConf.textContent = '🗑️ Purgar agora';

--- a/src/js/pages/contas.js
+++ b/src/js/pages/contas.js
@@ -103,7 +103,7 @@ function renderizarListas() {
   const bancosEl  = document.getElementById('bancos-lista');
 
   if (!cartoes.length) {
-    cartoesEl.innerHTML = '<p class="empty-state">Nenhum cartão cadastrado. Clique em "+ Novo Cartão" para adicionar.</p>';
+    cartoesEl.innerHTML = '<p class="empty-state">Nenhum cartão. Adicione o primeiro.</p>';
   } else {
     cartoesEl.innerHTML = cartoes.map(c => renderCartao(c)).join('');
   }
@@ -210,7 +210,8 @@ async function salvarSaldo(e) {
     fecharModalSaldo();
   } catch (err) {
     console.error('[contas] Erro ao salvar saldo:', err);
-    alert('Erro ao salvar saldo. Tente novamente.');
+    const el = document.getElementById('saldo-modal-erro');
+    if (el) { el.textContent = 'Não consegui salvar o saldo. Tente novamente.'; el.classList.remove('hidden'); }
   }
 }
 
@@ -301,7 +302,8 @@ async function salvarCartao(e) {
     fecharModalCartao();
   } catch (err) {
     console.error('[contas] Erro ao salvar cartão:', err);
-    alert('Erro ao salvar cartão. Tente novamente.');
+    const el = document.getElementById('cartao-modal-erro');
+    if (el) { el.textContent = 'Não consegui salvar o cartão. Tente novamente.'; el.classList.remove('hidden'); }
   }
 }
 

--- a/src/js/pages/despesas.js
+++ b/src/js/pages/despesas.js
@@ -192,8 +192,8 @@ function renderizarLista() {
 
   if (!filtradas.length) {
     lista.innerHTML = _despesas.length
-      ? emptyStateHTML('', 'Nenhuma despesa encontrada com os filtros aplicados.')
-      : emptyStateHTML('', 'Nenhuma despesa registrada neste período.', 'Clique em + Nova Despesa para começar.');
+      ? emptyStateHTML('', 'Nenhuma despesa para os filtros selecionados.')
+      : emptyStateHTML('', `Sem despesas em ${nomeMes(_mes)}.`, 'Adicione a primeira.');
     return;
   }
 
@@ -574,7 +574,7 @@ function configurarEventos() {
 // ── Exportação CSV ────────────────────────────────────────────
 function exportarCSV() {
   const exportaveis = _despesas.filter(isMovimentacaoReal);
-  if (!exportaveis.length) { alert('Nenhuma despesa para exportar neste período.'); return; }
+  if (!exportaveis.length) return;
 
   const cabecalho = ['Data', 'Descrição', 'Responsável', 'Categoria', 'Emoji', 'Parcela', 'Valor (R$)'];
   const ordenadas = [...exportaveis].sort((a, b) => {
@@ -621,7 +621,7 @@ window._despMarcarTransferencia = async (id) => {
     });
   } catch (err) {
     console.error('[despesas] Erro ao marcar transferência:', err);
-    alert('Erro ao marcar como transferência interna.');
+    /* error already logged above */
   }
 };
 window._despDesmarcarTransferencia = async (id) => {
@@ -633,6 +633,6 @@ window._despDesmarcarTransferencia = async (id) => {
     });
   } catch (err) {
     console.error('[despesas] Erro ao desmarcar transferência:', err);
-    alert('Erro ao desmarcar transferência interna.');
+    /* error already logged above */
   }
 };

--- a/src/js/pages/fatura.js
+++ b/src/js/pages/fatura.js
@@ -489,8 +489,8 @@ function ativarTab(tab) {
 
 // ── Exportação para Excel ─────────────────────────────────────
 function exportarExcel() {
-  if (typeof XLSX === 'undefined') { alert('SheetJS não carregado.'); return; }
-  if (!_despesas.length) { alert('Nenhuma transação para exportar.'); return; }
+  if (typeof XLSX === 'undefined') { console.error('[fatura] SheetJS não carregado'); return; }
+  if (!_despesas.length) return;
 
   const membros = _membrosDoGrupo();
   const totais  = calcularTotais(membros);
@@ -564,7 +564,7 @@ function atualizarTituloMes() {
 }
 
 function mostrarEmpty(show) {
-  document.getElementById('fat-empty').style.display         = show ? '' : 'none';
+  document.getElementById('fat-empty').style.display = show ? '' : 'none';
   document.getElementById('fat-resumo-cards').style.display  = show ? 'none' : '';
   document.getElementById('fat-conteudo').style.display      = show ? 'none' : '';
 }

--- a/src/js/pages/importar.js
+++ b/src/js/pages/importar.js
@@ -513,7 +513,7 @@ function _recategorizarComOrigem() {
 // ── NRF-004: Geração dinâmica do template Excel ─────────────────
 function gerarTemplateDespesas() {
   if (typeof XLSX === 'undefined') {
-    alert('SheetJS não carregado. Tente recarregar a página.');
+    console.error('[importar] SheetJS não carregado');
     return;
   }
   const wb = XLSX.utils.book_new();
@@ -556,7 +556,7 @@ function gerarTemplateDespesas() {
 
 // ── NRF-006: Template Extrato Bancário ──────────────────────────
 function gerarTemplateBanco() {
-  if (typeof XLSX === 'undefined') { alert('SheetJS não carregado. Tente recarregar a página.'); return; }
+  if (typeof XLSX === 'undefined') { console.error('[importar] SheetJS não carregado'); return; }
   const wb = XLSX.utils.book_new();
   const header  = ['Data', 'Descrição', 'Valor'];
   const exemplos = [
@@ -586,7 +586,7 @@ function gerarTemplateBanco() {
 
 // ── NRF-006: Template Receitas ───────────────────────────────────
 function gerarTemplateReceitas() {
-  if (typeof XLSX === 'undefined') { alert('SheetJS não carregado. Tente recarregar a página.'); return; }
+  if (typeof XLSX === 'undefined') { console.error('[importar] SheetJS não carregado'); return; }
   const wb = XLSX.utils.book_new();
   const catsReceita = _categorias.filter(c => c.tipo === 'receita').map(c => c.nome);
   const header = ['Data', 'Descrição', 'Categoria', 'Valor'];

--- a/src/js/pages/patrimonio.js
+++ b/src/js/pages/patrimonio.js
@@ -394,6 +394,15 @@ function renderizarGrafico(historico) {
 
 // ── Snapshot ──────────────────────────────────────────────────
 
+function _feedbackSnapshot(msg, isErro = false) {
+  const el = document.getElementById('snapshot-feedback');
+  if (!el) return;
+  el.textContent = msg;
+  el.className = `plan-feedback ${isErro ? 'plan-feedback-erro' : 'plan-feedback-ok'}`;
+  clearTimeout(el._t);
+  el._t = setTimeout(() => el.classList.add('hidden'), 3000);
+}
+
 async function salvarSnapshot() {
   const saldoContas       = calcularSaldoContas();
   const totalInv          = calcularTotalInvestimentos();
@@ -412,11 +421,11 @@ async function salvarSnapshot() {
       saldoContas,
       totalInvestimentos: totalInv,
     });
-    alert(`Snapshot de ${mesAno} salvo com sucesso.`);
+    _feedbackSnapshot(`✅ Snapshot ${mesAno} salvo`);
     carregarHistorico();
   } catch (err) {
     console.error('[patrimonio] Erro ao salvar snapshot:', err);
-    alert('Erro ao salvar snapshot. Tente novamente.');
+    _feedbackSnapshot('Não consegui salvar o snapshot. Tente novamente.', true);
   }
 }
 
@@ -481,7 +490,8 @@ async function salvarInvestimentoForm(e) {
     fecharModalInvestimento();
   } catch (err) {
     console.error('[patrimonio] Erro ao salvar investimento:', err);
-    alert('Erro ao salvar investimento. Tente novamente.');
+    const el = document.getElementById('inv-modal-erro');
+    if (el) { el.textContent = 'Não consegui salvar. Tente novamente.'; el.classList.remove('hidden'); }
   }
 }
 
@@ -556,7 +566,8 @@ async function salvarPassivoForm(e) {
     fecharModalPassivo();
   } catch (err) {
     console.error('[patrimonio] Erro ao salvar passivo:', err);
-    alert('Erro ao salvar dívida. Tente novamente.');
+    const el = document.getElementById('pass-modal-erro');
+    if (el) { el.textContent = 'Não consegui salvar. Tente novamente.'; el.classList.remove('hidden'); }
   }
 }
 

--- a/src/js/pages/receitas.js
+++ b/src/js/pages/receitas.js
@@ -112,7 +112,7 @@ function renderizarLista() {
   if (!container) return;
 
   if (!_receitas.length) {
-    container.innerHTML = emptyStateHTML('', 'Nenhuma receita registrada neste mês.', 'Clique em + Nova Receita para começar.');
+    container.innerHTML = emptyStateHTML('', `Sem receitas em ${nomeMes(_mes)}.`, 'Adicione a primeira.');
     return;
   }
 
@@ -195,6 +195,7 @@ function abrirModal(receita = null) {
 function fecharModal() {
   document.getElementById('modal-receita').style.display = 'none';
   document.getElementById('form-receita').reset();
+  _setErroModal('');
   _editandoId = null;
 }
 
@@ -208,17 +209,25 @@ function preencherSelectCategorias() {
 }
 
 // ── Salvar ─────────────────────────────────────────────────────
+function _setErroModal(msg) {
+  const el = document.getElementById('rec-modal-erro');
+  if (!el) return;
+  el.textContent = msg;
+  el.classList.toggle('hidden', !msg);
+}
+
 async function salvarReceita(e) {
   e.preventDefault();
+  _setErroModal('');
 
   const descricao   = document.getElementById('rec-descricao').value.trim();
   const valorRaw    = parseFloat(document.getElementById('rec-valor').value);
   const categoriaId = document.getElementById('rec-categoria').value;
   const dataVal     = document.getElementById('rec-data').value;
 
-  if (!descricao)           { alert('Informe uma descrição.');   return; }
-  if (!valorRaw || valorRaw <= 0) { alert('Informe um valor válido.'); return; }
-  if (!dataVal)             { alert('Informe a data.');           return; }
+  if (!descricao)                  { _setErroModal('Informe uma descrição.');  return; }
+  if (!valorRaw || valorRaw <= 0)  { _setErroModal('Informe um valor válido.'); return; }
+  if (!dataVal)                    { _setErroModal('Informe a data.');          return; }
 
   const dados = {
     grupoId:     _grupoId,
@@ -243,7 +252,7 @@ async function salvarReceita(e) {
     fecharModal();
   } catch (err) {
     console.error('[receitas] Erro ao salvar:', err);
-    alert('Erro ao salvar receita. Tente novamente.');
+    _setErroModal('Não consegui salvar a receita. Verifique sua conexão.');
   } finally {
     btnSalvar.disabled = false;
     btnSalvar.textContent = 'Salvar';
@@ -267,7 +276,7 @@ async function executarExclusao() {
     await excluirReceita(_excluindoId);
   } catch (err) {
     console.error('[receitas] Erro ao excluir:', err);
-    alert('Erro ao excluir receita.');
+    /* error already logged above */
   }
   fecharConfirmarExclusao();
 }
@@ -391,7 +400,7 @@ window._recMarcarTransferencia = async (id) => {
     });
   } catch (err) {
     console.error('[receitas] Erro ao marcar transferência:', err);
-    alert('Erro ao marcar como transferência interna.');
+    console.error('[receitas] Erro ao marcar transferência (já logado acima)');
   }
 };
 window._recDesmarcarTransferencia = async (id) => {
@@ -403,7 +412,7 @@ window._recDesmarcarTransferencia = async (id) => {
     });
   } catch (err) {
     console.error('[receitas] Erro ao desmarcar transferência:', err);
-    alert('Erro ao desmarcar transferência interna.');
+    console.error('[receitas] Erro ao desmarcar transferência (já logado acima)');
   }
 };
 
@@ -420,7 +429,7 @@ window._recDesmarcarTransferencia = async (id) => {
 
 // ── Geração de template xlsx via SheetJS ──────────────────────
 function _gerarTemplateRec() {
-  if (typeof XLSX === 'undefined') { alert('SheetJS não carregado.'); return; }
+  if (typeof XLSX === 'undefined') { console.error('[receitas] SheetJS não carregado'); return; }
   const wb = XLSX.utils.book_new();
   // Aba Receitas
   const dados = [

--- a/src/patrimonio.html
+++ b/src/patrimonio.html
@@ -101,6 +101,7 @@
         <h2 class="section-title"><i data-lucide="landmark" class="nav-sub-icon" aria-hidden="true"></i> Patrimônio</h2>
         <div class="section-actions">
           <button id="btn-snapshot" class="btn btn-outline btn-sm" title="Salvar snapshot mensal"><i data-lucide="camera" class="nav-sub-icon" aria-hidden="true"></i> Snapshot</button>
+          <span id="snapshot-feedback" class="plan-feedback hidden" style="font-size:var(--font-size-xs);padding:var(--space-1) var(--space-2);"></span>
         </div>
       </div>
 
@@ -192,6 +193,7 @@
           <label class="form-label" for="inv-observacoes">Observações</label>
           <textarea id="inv-observacoes" class="form-input" rows="2" placeholder="Notas opcionais"></textarea>
         </div>
+        <p class="form-erro hidden" id="inv-modal-erro"></p>
         <div class="modal-actions">
           <button type="button" id="btn-cancelar-inv" class="btn btn-outline">Cancelar</button>
           <button type="submit" id="btn-salvar-inv" class="btn btn-primary">Salvar</button>
@@ -246,6 +248,7 @@
           <label class="form-label" for="pass-observacoes">Observações</label>
           <textarea id="pass-observacoes" class="form-input" rows="2" placeholder="Notas opcionais"></textarea>
         </div>
+        <p class="form-erro hidden" id="pass-modal-erro"></p>
         <div class="modal-actions">
           <button type="button" id="btn-cancelar-pass" class="btn btn-outline">Cancelar</button>
           <button type="submit" id="btn-salvar-pass" class="btn btn-primary">Salvar</button>

--- a/src/receitas.html
+++ b/src/receitas.html
@@ -291,6 +291,8 @@
             <input type="date" id="rec-data" class="form-input" required />
           </div>
 
+          <p class="form-erro hidden" id="rec-modal-erro"></p>
+
           <div class="form-actions">
             <button type="button" class="btn btn-outline" id="btn-cancelar-rec">Cancelar</button>
             <button type="submit" class="btn btn-success" id="btn-salvar-rec">Salvar</button>


### PR DESCRIPTION
## Resumo

- `docs/MF_Microcopy.md` — guia de tom de voz, padrões de botão/empty state/erro/sucesso, glossário, 20 exemplos antes × depois
- Todos os `alert()` removidos do app (7 arquivos) — substituídos por: elementos `form-erro` inline, `mostrarToast()`, `_feedbackSnapshot()`, ou `console.error` para erros silenciosos
- Empty states com mês dinâmico: `Sem receitas em {mês}.` / `Sem despesas em {mês}.`
- Mensagens de erro padronizadas: `Não consegui salvar…` em vez de `Erro ao salvar…`

## Subagentes

- **test-runner:** ✅ 753/753 PASS (2 runs)
- **ux-reviewer:** ✅ APPROVED WITH NOTES — PUX5-B (fecharModal limpa erro) e PUX5-A (mês dinâmico) corrigidos no mesmo commit. LOW PUX4-A (snapshot-feedback inline style) e PUX5-C (delete silence) documentados para follow-up.

## Issues relacionadas

Closes #200

## Notas de merge

Branch baseada em `main` (v3.39.5). Necessitará rebase após PRs #206 e #207 mesclados — conflito trivial de versão em `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)