### PR TITLE
feat(empty-states): ENH-007 empty states em fatura e fluxo-caixa (#210)

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -804,9 +804,11 @@ h1, h2 { font-family: var(--font-display); }
   font-size: var(--font-size-sm);
   padding: var(--space-10) var(--space-6);
 }
-.empty-state__icon  { font-size: 2rem; line-height: 1; }
+.empty-state__icon  { font-size: 2rem; line-height: 1; color: var(--color-text-muted); }
 .empty-state__title { font-weight: 600; font-size: var(--font-size-md); }
 .empty-state__hint  { font-size: var(--font-size-xs); }
+.empty-state__cta   { margin-top: var(--space-4); display: flex; gap: var(--space-2); justify-content: center; flex-wrap: wrap; }
+.empty-state--compact { padding: var(--space-6) var(--space-4); }
 
 /* Badge genérico */
 .badge {

--- a/src/js/pages/fatura.js
+++ b/src/js/pages/fatura.js
@@ -13,9 +13,13 @@ import { onAuthChange, logout } from '../services/auth.js';
 import { buscarPerfil, buscarGrupo, ouvirContas, ouvirCategorias, ouvirDespesas, ouvirDespesasPorMesFatura, garantirContasPadrao } from '../services/database.js';
 import { formatarMoeda, formatarData, nomeMes, escHTML } from '../utils/formatters.js';
 import { recalcularScoreFatura } from '../utils/reconciliadorFatura.js';
-import { skeletonTableRows, skeletonChart, errorStateHTML } from '../utils/skeletons.js';
+import { skeletonTableRows, skeletonChart, errorStateHTML, emptyStateHTML } from '../utils/skeletons.js';
 import { CONTAS_PADRAO } from '../models/Conta.js';
 import { iniciar as iniciarProjecoes } from '../utils/projecoesCartao.js';
+
+// ── Ícones SVG para empty states ──────────────────────────────
+const SVG_INBOX = '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>';
+const SVG_FILTER_EMPTY = '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="2" y1="3" x2="22" y2="3"/><line x1="6" y1="9" x2="18" y2="9"/><line x1="10" y1="15" x2="14" y2="15"/><line x1="8" y1="18" x2="16" y2="18"/><line x1="18" y1="12" x2="22" y2="16"/><line x1="22" y1="12" x2="18" y2="16"/></svg>';
 
 // ── Estado ────────────────────────────────────────────────────
 let _usuario    = null;
@@ -186,6 +190,12 @@ function recarregarDespesas() {
 
 // ── Render principal ──────────────────────────────────────────
 function renderizarTudo() {
+  // ENH-007 Cenário A — cartão selecionado mas período sem despesas
+  if (!_despesas.length) {
+    mostrarEmpty(true, 'semDados');
+    return;
+  }
+  mostrarEmpty(false);
   const membros = _membrosDoGrupo();
   renderizarCards(membros);
   gerarTabsMembros(membros);
@@ -314,8 +324,29 @@ function renderizarTabela(tipo) {
     const rows = _despesas
       .filter(d => !busca || (d.descricao ?? '').toLowerCase().includes(busca))
       .sort((a, b) => _toTs(b.data) - _toTs(a.data));
-    tbody.innerHTML = rows.map(d => _rowTodas(d)).join('') ||
-      '<tr><td colspan="8" class="fat-td-empty">Nenhuma transação</td></tr>';
+    if (!rows.length) {
+      if (busca && _despesas.length) {
+        // ENH-007 Cenário B — filtro sem resultado
+        tbody.innerHTML = `<tr><td colspan="8">
+          <div class="empty-state empty-state--compact" role="status">
+            <span class="empty-state__icon" aria-hidden="true">${SVG_FILTER_EMPTY}</span>
+            <p class="empty-state__title">Nenhum resultado com os filtros aplicados.</p>
+            <p class="empty-state__hint">Ajuste a busca ou limpe para ver todos os lançamentos.</p>
+            <div class="empty-state__cta">
+              <button class="btn btn-outline btn-sm fat-busca-limpar">Limpar busca</button>
+            </div>
+          </div>
+        </td></tr>`;
+        tbody.querySelector('.fat-busca-limpar')?.addEventListener('click', () => {
+          const inp = document.getElementById('fat-busca');
+          if (inp) { inp.value = ''; renderizarTabela('todas'); }
+        });
+      } else {
+        tbody.innerHTML = '<tr><td colspan="8" class="fat-td-empty">Nenhuma transação</td></tr>';
+      }
+      return;
+    }
+    tbody.innerHTML = rows.map(d => _rowTodas(d)).join('');
     return;
   }
 
@@ -563,10 +594,31 @@ function atualizarTituloMes() {
   document.getElementById('fat-mes-titulo').textContent = `${nomeMes(_mes)} ${_ano}`;
 }
 
-function mostrarEmpty(show) {
-  document.getElementById('fat-empty').style.display = show ? '' : 'none';
-  document.getElementById('fat-resumo-cards').style.display  = show ? 'none' : '';
-  document.getElementById('fat-conteudo').style.display      = show ? 'none' : '';
+/**
+ * @param {boolean} show
+ * @param {'semCartao'|'semDados'} [tipo='semCartao']
+ */
+function mostrarEmpty(show, tipo = 'semCartao') {
+  const el = document.getElementById('fat-empty');
+  if (show) {
+    if (tipo === 'semDados') {
+      // ENH-007 Cenário A — cartão selecionado mas sem despesas no período
+      el.innerHTML = emptyStateHTML(
+        SVG_INBOX,
+        `Nenhuma despesa em ${escHTML(nomeMes(_mes))}/${_ano}.`,
+        'Importe um extrato da fatura ou adicione uma despesa manualmente.',
+        `<a href="importar.html" class="btn btn-primary btn-sm">Importar extrato</a>
+         <a href="despesas.html" class="btn btn-outline btn-sm">Adicionar despesa</a>`
+      );
+    } else {
+      el.innerHTML = `
+        <div class="fat-empty-icon"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg></div>
+        <p>Selecione um cartão para visualizar a fatura do mês.</p>`;
+    }
+  }
+  el.style.display = show ? '' : 'none';
+  document.getElementById('fat-resumo-cards').style.display = show ? 'none' : '';
+  document.getElementById('fat-conteudo').style.display     = show ? 'none' : '';
 }
 
 function _toTs(data) {

--- a/src/js/pages/fluxo-caixa.js
+++ b/src/js/pages/fluxo-caixa.js
@@ -17,7 +17,11 @@ import { gerarForecast } from '../utils/forecastEngine.js';
 import { coresGrafico } from '../utils/chartColors.js';
 import { isMovimentacaoReal } from '../utils/helpers.js';
 import { buscarProjecoesAgregadas } from '../utils/projecoesCartao.js';
-import { skeletonTableRows } from '../utils/skeletons.js';
+import { skeletonTableRows, emptyStateHTML } from '../utils/skeletons.js';
+
+// ── Ícones SVG para empty states ──────────────────────────────
+const SVG_BAR_CHART = '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/><line x1="2" y1="20" x2="22" y2="20"/></svg>';
+const SVG_CHECK_CIRCLE = '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>';
 
 // ── Constantes ────────────────────────────────────────────────
 
@@ -296,8 +300,17 @@ function renderizarTabela(dados) {
   const tbody = document.getElementById('fc-tbody');
   if (!tbody) return;
 
-  if (!dados.length) {
-    tbody.innerHTML = '<tr><td colspan="7" class="fc-empty">Nenhum dado para o período.</td></tr>';
+  // ENH-007 Cenário A — ano selecionado sem nenhuma movimentação
+  const temDados = dados.some(d => d.rec > 0 || d.desp > 0);
+  if (!temDados) {
+    tbody.innerHTML = `<tr><td colspan="7">
+      ${emptyStateHTML(
+        SVG_BAR_CHART,
+        `Nenhuma movimentação em ${_ano}.`,
+        'Adicione uma receita ou despesa para começar.',
+        `<a href="despesas.html" class="btn btn-primary btn-sm">Nova movimentação</a>`
+      )}
+    </td></tr>`;
     return;
   }
 
@@ -419,7 +432,13 @@ function renderizarForecast(forecast) {
   }
 
   if (!forecast.length) {
-    tbody.innerHTML = '<tr><td colspan="6" class="fc-empty">Sem dados para forecast.</td></tr>';
+    tbody.innerHTML = `<tr><td colspan="6">
+      ${emptyStateHTML(
+        SVG_BAR_CHART,
+        'Sem dados suficientes para forecast.',
+        'Adicione movimentações dos últimos meses para ativar a previsão.'
+      )}
+    </td></tr>`;
     return;
   }
 
@@ -465,7 +484,13 @@ async function carregarCompromissos() {
 
     const temDados = meses.some(m => m.total > 0);
     if (!temDados) {
-      tbody.innerHTML = '<tr><td colspan="2" class="fc-empty">Nenhuma parcela comprometida nos próximos 6 meses.</td></tr>';
+      tbody.innerHTML = `<tr><td colspan="2">
+        ${emptyStateHTML(
+          SVG_CHECK_CIRCLE,
+          'Nenhuma parcela comprometida nos próximos 6 meses.',
+          'Ótimo — sem compromissos futuros de cartão.'
+        )}
+      </td></tr>`;
       return;
     }
 

--- a/src/js/utils/skeletons.js
+++ b/src/js/utils/skeletons.js
@@ -88,17 +88,19 @@ export function skeletonPatrimonioItems(count = 3) {
 
 /**
  * Gera bloco de empty-state centralizado.
- * @param {string} icon    — emoji ou ícone
- * @param {string} title   — título principal
- * @param {string} [hint]  — dica secundária
+ * @param {string} icon       — emoji, SVG inline ou ícone
+ * @param {string} title      — título principal
+ * @param {string} [hint]     — dica secundária
+ * @param {string} [ctaHtml]  — HTML do(s) CTA(s) (botões/links)
  * @returns {string} HTML string
  */
-export function emptyStateHTML(icon, title, hint = '') {
+export function emptyStateHTML(icon, title, hint = '', ctaHtml = '') {
   return `
-    <div class="empty-state">
-      <span class="empty-state__icon">${icon}</span>
+    <div class="empty-state" role="status">
+      <span class="empty-state__icon" aria-hidden="true">${icon}</span>
       <p class="empty-state__title">${title}</p>
       ${hint ? `<p class="empty-state__hint">${hint}</p>` : ''}
+      ${ctaHtml ? `<div class="empty-state__cta">${ctaHtml}</div>` : ''}
     </div>`;
 }
 


### PR DESCRIPTION
## O que foi feito

Implementa 5 empty states cobrindo Cenários A (zero dados) e B (filtro sem resultado) em `fatura.html` e `fluxo-caixa.html`.

### fatura.js
- **Cenário A** — cartão selecionado mas sem despesas no período: ícone inbox (SVG Lucide) + `Nenhuma despesa em [Mês]/[ano].` + hint + CTAs `Importar extrato` + `Adicionar despesa`
- **Cenário B** — busca (`fat-busca`) sem resultado com dados no período: ícone filter + `Nenhum resultado com os filtros aplicados.` + CTA `Limpar busca`

### fluxo-caixa.js
- **Cenário A** — ano selecionado sem movimentações: ícone bar-chart + `Nenhuma movimentação em [ano].` + CTA `Nova movimentação`
- **Forecast vazio** — sem dados históricos suficientes: empty state com ícone + microcopy orientativo
- **Compromissos vazios** — sem parcelas futuras: empty state com ícone check-circle + microcopy positivo

### Infraestrutura
- `skeletons.js`: `emptyStateHTML` recebe 4º param `ctaHtml` opcional + `role="status"` + `aria-hidden="true"` no ícone
- `components.css`: `.empty-state__cta` (flex, gap, margin-top) + `.empty-state--compact` (padding reduzido para contexto de tabela)

## Subagentes

- **test-runner**: ✅ PASS — 844/844 testes passando, build 2.13s
- **security-reviewer**: ✅ PASS — 0 Critical/High; 1 Low (sem JSDoc em emptyStateHTML sobre responsabilidade do caller); nenhum dado Firestore/usuário refletido em innerHTML
- **ux-reviewer**: ✅ APROVADO — PUX1–PUX6 PASS; 3 sugestões não bloqueantes (font-size em ícone SVG, role="status" em busca reativa, inconsistência pré-existente em estado semCartao)

## Microcopy (MF_Microcopy.md)

| Cenário | Título | Tom |
|---|---|---|
| fatura período vazio | Nenhuma despesa em [Mês]/[ano]. | Factual |
| fatura busca vazia | Nenhum resultado com os filtros aplicados. | Factual |
| fluxo-caixa ano vazio | Nenhuma movimentação em [ano]. | Factual |
| forecast sem dados | Sem dados suficientes para forecast. | Orientativo |
| compromissos vazio | Nenhuma parcela comprometida nos próximos 6 meses. | Positivo |

## Como testar

- [ ] `npm test` → 844/844 passando
- [ ] `npm run build` → sem warnings
- [ ] fatura.html: selecionar cartão sem despesas no mês → Cenário A visível
- [ ] fatura.html: digitar texto inexistente na busca → Cenário B visível + "Limpar busca" funciona
- [ ] fluxo-caixa.html: selecionar ano sem dados → tabela anual mostra empty state
- [ ] Verificar sem regressão quando há dados normais

## Checklist

- [x] 844 testes passando
- [x] Build sem warnings
- [x] `escHTML()` aplicado em strings dinâmicas (nomeMes/_ano são safe; escHTML usado defensivamente)
- [x] Sem cores hardcoded — tokens CSS em todo CSS adicionado
- [x] `role="status"` + `aria-hidden="true"` em todos os empty states
- [x] CTAs com texto descritivo (não "Clique aqui")
- [x] Sem regressão nos estados existentes (skeleton, error-state)
- [x] security-reviewer PASS
- [x] ux-reviewer APROVADO
- [x] Milestone "Polimento Visual v3.40.0" referenciado
- [x] Sem bump de versão (bump só no PR 3/ENH-006)
- [x] Sem CHANGELOG (consolidado no PR 3)

Closes #210