### PR TITLE
feat(cockpit): ENH-006 densidade em mobile <414px (v3.40.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [3.40.0] - 2026-04-23
+
+### Adicionado
+
+- **ENH-007 — Empty states em fatura e fluxo-caixa (PR #213):** estados semânticos de ausência de dados e filtro vazio nas telas de Fatura e Fluxo de Caixa.
+  - `src/js/utils/skeletons.js`: `emptyStateHTML()` agora aceita 4º argumento `ctaHtml` para botões de ação; `.empty-state` recebe `role="status"`; `.empty-state__icon` ganha `aria-hidden="true"`.
+  - `src/css/components.css`: tokens `.empty-state__cta`, `.empty-state--compact` e `color: var(--color-text-muted)` para o ícone.
+  - `src/js/pages/fatura.js`: Cenário A (sem despesas no mês) e Cenário B (filtro de busca sem resultado) com ícones SVG inline, microcopy contextual e CTA "Limpar busca".
+  - `src/js/pages/fluxo-caixa.js`: Cenário A (ano sem movimentações) com CTA "Nova movimentação"; empty states de Forecast e Compromissos.
+- **RF-071 — Tokens de cor em séries Chart.js (PR #214):** cores dos gráficos lidas via CSS custom properties, eliminando hex hardcoded.
+  - `src/css/variables.css`: tokens `--chart-grid` e `--chart-point-border` com overrides para dark mode.
+  - `src/js/utils/chartColors.js`: `getChartColors()` (semântico + patrimônio/ativos/passivos), `CORES_CATEGORIA` (paleta Tableau10, 12 slots), `corPorIndice(i)`.
+  - `src/js/pages/fluxo-caixa.js` + `src/js/pages/patrimonio.js`: 9 valores hex/rgba hardcoded substituídos por `getChartColors()`.
+- **ENH-006 — Densidade do cockpit em mobile <414px (PR #215):** ajustes de espaçamento, cards KPI e touch targets para iPhones SE/mini e Androids compactos.
+  - `src/css/main.css`: `@media (max-width: 413px)` com `.resumo-cards` em 2 colunas (~164px em 360px), `.resumo-card` com padding 12px, `.resumo-valor` reduzido para 17px, `.section-actions .btn` com `min-height: 44px` (Apple HIG), `.main-content` com padding lateral 12px e gap 32px entre seções.
+
 ## [3.39.8] - 2026-04-23
 
 ### Adicionado

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minhas-financas",
-  "version": "3.39.8",
+  "version": "3.40.0",
   "description": "Aplicativo web de gestão financeira familiar com Firebase",
   "main": "src/js/app.js",
   "type": "module",

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -172,6 +172,51 @@ a:hover { text-decoration: underline; }
   .resumo-cards { grid-template-columns: 1fr; }
 }
 
+/* ── Mobile pequeno (<414px) — ENH-006 densidade cockpit ── */
+@media (max-width: 413px) {
+  /* Padding lateral comprimido para maximizar conteúdo útil */
+  .main-content {
+    padding-left: calc(var(--space-3) + var(--safe-area-left));
+    padding-right: calc(var(--space-3) + var(--safe-area-right));
+    gap: var(--space-8);
+  }
+
+  /* 2 colunas de KPI cards: ~164px cada em 360px — acima do mínimo de 140px */
+  .resumo-cards {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-2);
+  }
+
+  /* Card KPI: padding interno comprimido */
+  .resumo-card {
+    padding: var(--space-3);
+  }
+
+  /* Valor KPI: 17px em vez de 22px — legível em coluna estreita */
+  .resumo-valor {
+    font-size: var(--font-size-lg);
+  }
+
+  /* Section header: spacing comprimido entre título e ações */
+  .section-header {
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+  }
+
+  /* CTAs: alvo de toque ≥44px (Apple HIG) — empilhados e esticados */
+  .section-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .section-actions .btn,
+  .section-actions a.btn {
+    min-height: var(--touch-target-min);
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+}
+
 /* ============================================================
    RF-004 — Página de Orçamentos
    ============================================================ */

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -185,6 +185,7 @@
   --space-8:    32px;
   --space-10:   40px;
   --space-12:   48px;
+  --touch-target-min: 44px;  /* Apple HIG mínimo de alvo de toque */
 
   /* ── Ritmo vertical de página (NRF-UX F6 #198) ──────────── */
   --rhythm-sm: var(--space-3);    /* 12px — entre label e input */


### PR DESCRIPTION
## Resumo

PR 3/3 do milestone **Polimento Visual v3.40.0** — faz o bump de versão e fecha o milestone.

- `variables.css`: token `--touch-target-min: 44px` (Apple HIG mínimo de alvo de toque)
- `main.css`: `@media (max-width: 413px)` com density fixes para dashboard, patrimônio, fluxo-caixa e orçamentos:
  - `.resumo-cards`: 2 colunas (~164px em 360px, acima do mínimo de 140px) — sobrescreve 1-coluna do <480px
  - `.resumo-card`: `padding: var(--space-3)` (12px, comprimido de 20px)
  - `.resumo-valor`: `font-size: var(--font-size-lg)` (17px, legível em coluna estreita)
  - `.section-header`: gap 8px, margin-bottom 12px
  - `.section-actions`: empilhado (column) com `min-height: var(--touch-target-min)` nos botões
  - `.main-content`: padding lateral 12px + gap 32px entre seções
- `package.json`: bump para **v3.40.0**
- `CHANGELOG.md`: entrada consolidada v3.40.0 (ENH-007 + RF-071 + ENH-006)

## Critérios de aceite verificados

- [x] Em 360px: 2 colunas de KPI cards (~164px cada — acima de 140px mínimo), font-size 17px
- [x] Espaçamento vertical entre seções: 32px (≥16px mínimo)
- [x] CTAs: `min-height: var(--touch-target-min) = 44px` (Apple HIG)
- [x] Padding lateral: 12px (mais conteúdo útil que 16px)
- [x] Viewports ≥414px: sem impacto (breakpoint `max-width: 413px`)
- [x] Zero hardcoded values — tudo via tokens de variables.css

## Verificação

- 844/844 testes unitários passando
- ux-reviewer subagent: **APROVADO** (PUX1–PUX6 todos ✓, incluindo re-review após fix do token)

## Contexto

Fecha o milestone **Polimento Visual v3.40.0** (3 PRs: #213 ENH-007, #214 RF-071, #215 ENH-006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)