### PR TITLE
fix(contas): modais de erro de saldo e cartão exibem validação (BUG-038 #223)

### DIFF
--- a/src/js/pages/contas.js
+++ b/src/js/pages/contas.js
@@ -186,6 +186,8 @@ function abrirModalSaldo(contaId) {
   document.getElementById('modal-saldo-titulo').textContent = `Saldo — ${c.nome}`;
   document.getElementById('inp-saldo-inicial').value   = c.saldoInicial != null ? Number(c.saldoInicial) : '';
   document.getElementById('inp-data-referencia').value = c.dataReferenciaSaldo ?? '';
+  const erroSaldo = document.getElementById('saldo-modal-erro');
+  if (erroSaldo) { erroSaldo.textContent = ''; erroSaldo.classList.add('hidden'); }
   document.getElementById('modal-saldo-banco').classList.remove('hidden');
 }
 
@@ -203,7 +205,14 @@ async function salvarSaldo(e) {
   const saldoInicial        = parseFloat(document.getElementById('inp-saldo-inicial').value);
   const dataReferenciaSaldo = document.getElementById('inp-data-referencia').value;
 
-  if (isNaN(saldoInicial) || !dataReferenciaSaldo) return;
+  if (isNaN(saldoInicial) || !dataReferenciaSaldo) {
+    const el = document.getElementById('saldo-modal-erro');
+    if (el) {
+      el.textContent = isNaN(saldoInicial) ? 'Informe um valor de saldo válido.' : 'Informe a data de referência.';
+      el.classList.remove('hidden');
+    }
+    return;
+  }
 
   try {
     await atualizarConta(_editandoSaldoId, { saldoInicial, dataReferenciaSaldo });
@@ -234,6 +243,12 @@ function configurarEventos() {
   document.getElementById('form-saldo-banco').addEventListener('submit', salvarSaldo);
   document.getElementById('modal-saldo-banco').addEventListener('click', (e) => {
     if (e.target.id === 'modal-saldo-banco') fecharModalSaldo();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (!document.getElementById('modal-cartao').classList.contains('hidden')) fecharModalCartao();
+    if (!document.getElementById('modal-saldo-banco').classList.contains('hidden')) fecharModalSaldo();
   });
 }
 
@@ -267,6 +282,8 @@ function abrirModalCartao(contaId) {
     document.getElementById('inp-cartao-cor').value   = '#7B1FA2';
   }
 
+  const erroCartao = document.getElementById('cartao-modal-erro');
+  if (erroCartao) { erroCartao.textContent = ''; erroCartao.classList.add('hidden'); }
   document.getElementById('modal-cartao').classList.remove('hidden');
 }
 
@@ -292,6 +309,12 @@ async function salvarCartao(e) {
     contaPagadoraId: document.getElementById('sel-cartao-pagadora').value || undefined,
     titularPadraoId: document.getElementById('sel-cartao-titular').value || undefined,
   });
+
+  if (!dados.nome) {
+    const el = document.getElementById('cartao-modal-erro');
+    if (el) { el.textContent = 'O nome do cartão é obrigatório.'; el.classList.remove('hidden'); }
+    return;
+  }
 
   try {
     if (_editandoId) {


### PR DESCRIPTION
## 📝 Descrição

Correção de UX silenciosa ao submeter dados inválidos nos modais de Contas:

**`salvarSaldo()`** — antes retornava silenciosamente com `return` se `saldoInicial` fosse NaN ou `dataReferenciaSaldo` estivesse vazio. Agora exibe `#saldo-modal-erro` com mensagem específica.

**`salvarCartao()`** — antes não validava nome vazio no lado JS (dependia só de `required` HTML5). Agora valida e exibe `#cartao-modal-erro`.

**Ambos os modais:**
- Limpam mensagem de erro ao reabrir
- Fecham via tecla Esc (handler adicionado em `configurarEventos()`)

## 🎯 Issue Relacionada
Closes #223

## 🔄 Tipo de Mudança
- [x] 🐛 Bug fix (corrige um problema sem quebrar funcionalidades existentes)

## ✅ Checklist
- [x] Meu código segue as convenções do projeto
- [x] Fiz self-review do meu próprio código
- [x] O CHANGELOG.md foi atualizado
- [x] `npm test` passando (851 testes)
- [x] Sem credenciais Firebase no diff

## 🎨 UI/CSS — Regra Inviolável #14 (pular se PR não toca HTML/CSS/innerHTML)
**N/A** — PR toca `src/js/pages/contas.js` mas as mudanças usam exclusivamente `textContent`, `classList`, e `addEventListener`. Nenhuma geração de HTML via `innerHTML`. O elemento `<p class="form-erro hidden">` já existe no HTML e está totalmente estilizado. A Regra #14 não é acionada.

## 📎 Notas Adicionais
Microcopy das mensagens de erro: alinhado com `docs/MF_Microcopy.md`:
- `'Informe um valor de saldo válido.'`
- `'Informe a data de referência.'`
- `'O nome do cartão é obrigatório.'`