### PR TITLE
fix(patrimonio): modais de erro de investimento e passivo (BUG-039 #224)

### DIFF
--- a/src/js/pages/patrimonio.js
+++ b/src/js/pages/patrimonio.js
@@ -460,6 +460,8 @@ function abrirModalInvestimento(id = null) {
     titulo.textContent = 'Novo Investimento';
   }
 
+  const erroInv = document.getElementById('inv-modal-erro');
+  if (erroInv) { erroInv.textContent = ''; erroInv.classList.add('hidden'); }
   modal.style.display = 'flex';
 }
 
@@ -481,6 +483,17 @@ async function salvarInvestimentoForm(e) {
     observacoes:  document.getElementById('inv-observacoes').value || undefined,
     dataAtualizacao: new Date(),
   });
+
+  if (!dados.nome) {
+    const el = document.getElementById('inv-modal-erro');
+    if (el) { el.textContent = 'O nome do investimento é obrigatório.'; el.classList.remove('hidden'); }
+    return;
+  }
+  if (!dados.valorAplicado || dados.valorAplicado <= 0) {
+    const el = document.getElementById('inv-modal-erro');
+    if (el) { el.textContent = 'Informe um valor aplicado maior que zero.'; el.classList.remove('hidden'); }
+    return;
+  }
 
   try {
     if (_editandoInvId) {
@@ -533,6 +546,8 @@ function abrirModalPassivo(id = null) {
     document.getElementById('pass-data-origem').value      = HOJE_STR;
   }
 
+  const erroPass = document.getElementById('pass-modal-erro');
+  if (erroPass) { erroPass.textContent = ''; erroPass.classList.add('hidden'); }
   modal.style.display = 'flex';
 }
 
@@ -557,6 +572,17 @@ async function salvarPassivoForm(e) {
     status:         document.getElementById('pass-status').value,
     observacoes:    document.getElementById('pass-observacoes').value || undefined,
   });
+
+  if (!dados.credor) {
+    const el = document.getElementById('pass-modal-erro');
+    if (el) { el.textContent = 'O nome do credor é obrigatório.'; el.classList.remove('hidden'); }
+    return;
+  }
+  if (isNaN(valorOrig) || valorOrig <= 0) {
+    const el = document.getElementById('pass-modal-erro');
+    if (el) { el.textContent = 'Informe um valor original válido (maior que zero).'; el.classList.remove('hidden'); }
+    return;
+  }
 
   try {
     if (_editandoPassId) {
@@ -604,4 +630,11 @@ function configurarEventos() {
   document.getElementById('btn-cancelar-conf').addEventListener('click', fecharModalConfirmar);
   document.getElementById('modal-conf-overlay').addEventListener('click', fecharModalConfirmar);
   document.getElementById('btn-confirmar-conf').addEventListener('click', () => { if (_confirmarCb) _confirmarCb(); });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (document.getElementById('modal-investimento').style.display !== 'none') fecharModalInvestimento();
+    if (document.getElementById('modal-passivo').style.display !== 'none') fecharModalPassivo();
+    if (document.getElementById('modal-confirmar').style.display !== 'none') fecharModalConfirmar();
+  });
 }


### PR DESCRIPTION
## 📝 Descrição

Correção de UX silenciosa nos modais de Patrimônio (formulários usam `novalidate` — JS é a única camada de validação):

**`salvarInvestimentoForm()`** — agora valida nome obrigatório e `valorAplicado > 0`, exibindo `#inv-modal-erro` com mensagem específica.

**`salvarPassivoForm()`** — agora valida credor obrigatório e `valorOriginal > 0`, exibindo `#pass-modal-erro` com mensagem específica.

**Ambos os modais:**
- Limpam mensagem de erro ao reabrir
- Fecham via tecla Esc (incluindo modal de confirmação)

## 🎯 Issue Relacionada
Closes #224

## 🔄 Tipo de Mudança
- [x] 🐛 Bug fix (corrige um problema sem quebrar funcionalidades existentes)

## ✅ Checklist
- [x] Meu código segue as convenções do projeto
- [x] Fiz self-review do meu próprio código
- [x] O CHANGELOG.md foi atualizado
- [x] `npm test` passando (851 testes)
- [x] Sem credenciais Firebase no diff

## 🎨 UI/CSS — Regra Inviolável #14 (pular se PR não toca HTML/CSS/innerHTML)
**N/A** — mudanças em `src/js/pages/patrimonio.js` usam exclusivamente `textContent`, `classList`, e `addEventListener`. Sem geração de HTML via `innerHTML`. Regra #14 não acionada.

## 📎 Notas Adicionais
Mensagens: `'O nome do investimento é obrigatório.'`, `'Informe um valor aplicado maior que zero.'`, `'O nome do credor é obrigatório.'`, `'Informe um valor original válido (maior que zero).'`