### PR TITLE
fix(fluxo-caixa): exibir dados e projeções de meses históricos (BUG-036 #221)

### DIFF
--- a/src/js/pages/fluxo-caixa.js
+++ b/src/js/pages/fluxo-caixa.js
@@ -123,22 +123,23 @@ function agregarMensalmente(despesas, receitas, orcamentos) {
   const despMes = Array(12).fill(0);
   const orcMes  = Array(12).fill(0);
 
+  // getUTCMonth() evita deslocamento de mês em datas armazenadas como UTC midnight
   receitas.forEach((r) => {
     const d = r.data?.toDate?.() ?? new Date(r.data);
-    recMes[d.getMonth()] += r.valor ?? 0;
+    recMes[d.getUTCMonth()] += r.valor ?? 0;
   });
 
-  // Exclui projeções e transferências internas das despesas realizadas
-  despesas.filter(isMovimentacaoReal).forEach((d) => {
+  // Exclui projeções, transferências internas e projecao_paga (o doc despesa real já conta)
+  despesas.filter(d => isMovimentacaoReal(d) && d.tipo !== 'projecao_paga').forEach((d) => {
     const dt = d.data?.toDate?.() ?? new Date(d.data);
-    despMes[dt.getMonth()] += d.valor ?? 0;
+    despMes[dt.getUTCMonth()] += d.valor ?? 0;
   });
 
-  // Inclui projeções separadas para visualização futura
+  // Inclui projeções pendentes (não reconciliadas) para todos os meses
   const projMes = Array(12).fill(0);
   despesas.filter((d) => d.tipo === 'projecao').forEach((d) => {
     const dt = d.data?.toDate?.() ?? new Date(d.data);
-    projMes[dt.getMonth()] += d.valor ?? 0;
+    projMes[dt.getUTCMonth()] += d.valor ?? 0;
   });
 
   orcamentos.forEach((o) => {
@@ -301,7 +302,7 @@ function renderizarTabela(dados) {
   if (!tbody) return;
 
   // ENH-007 Cenário A — ano selecionado sem nenhuma movimentação
-  const temDados = dados.some(d => d.rec > 0 || d.desp > 0);
+  const temDados = dados.some(d => d.rec > 0 || d.desp > 0 || d.proj > 0);
   if (!temDados) {
     tbody.innerHTML = `<tr><td colspan="7">
       ${emptyStateHTML(
@@ -316,14 +317,14 @@ function renderizarTabela(dados) {
 
   const mesAtualIdx = new Date().getFullYear() === _ano ? new Date().getMonth() : -1;
 
-  tbody.innerHTML = dados.map(({ mes, rec, desp, orc, saldo, acum, isFuturo }) => {
+  tbody.innerHTML = dados.map(({ mes, rec, desp, proj, orc, saldo, acum, isFuturo }) => {
     const isAtual = mes === mesAtualIdx;
-    const situacao = getSituacao(rec, desp, orc, isFuturo);
+    const situacao = getSituacao(rec, desp + proj, orc, isFuturo);
     return `
       <tr class="${isAtual ? 'fc-tr--atual' : ''} ${isFuturo ? 'fc-tr--futuro' : ''}">
         <td class="fc-td-mes">${isAtual ? '▶ ' : ''}${MESES_COMPLETOS[mes]}</td>
         <td class="fc-td-num fc-verde">${fmt(rec)}</td>
-        <td class="fc-td-num fc-vermelho">${fmt(desp)}</td>
+        <td class="fc-td-num fc-vermelho">${fmt(desp + proj)}</td>
         <td class="fc-td-num fc-cinza">${orc ? fmt(orc) : '—'}</td>
         <td class="fc-td-num ${saldo >= 0 ? 'fc-verde' : 'fc-vermelho'}">${fmt(saldo)}</td>
         <td class="fc-td-num ${acum >= 0 ? 'fc-azul' : 'fc-vermelho'}">${fmt(acum)}</td>


### PR DESCRIPTION
## Root causes

Three independent bugs caused historical months to appear empty:

1. **UTC midnight timezone shift** — dates stored as `T00:00:00Z` (UTC midnight) shifted to the previous month via `getMonth()` in UTC-3. Fixed with `getUTCMonth()`.
2. **`projecao_paga` double-counting** — when a projeção is reconciled via import, both the original `projecao` doc AND the new `despesa` doc exist. The old filter (`isMovimentacaoReal`) counted `projecao_paga` as real spend, doubling the value. Excluded via `d.tipo !== 'projecao_paga'`.
3. **`temDados` missed projection-only months** — months with only pending projections (no real despesas/receitas) triggered the "no data" empty state. Fixed by adding `|| d.proj > 0` to the guard.

## Changes

- `agregarMensalmente()`: `getMonth()` → `getUTCMonth()`; exclude `projecao_paga` from `despMes`; new `projMes` accumulator for pending projections
- `renderizarTabela()`: `temDados` includes `d.proj > 0`; Despesas column shows `desp + proj`; `getSituacao` receives `desp + proj` (consistent with the bar chart, which already used `desp + proj`)

## Testing

- 851/851 unit tests passing
- ux-reviewer subagent: **APPROVED** (PUX1–PUX6 all pass)

## Closes

Fixes #221 (BUG-036)

🤖 Generated with [Claude Code](https://claude.com/claude-code)