### PR TITLE
fix(fatura): buscar pagamentos de fatura via query dedicada (BUG-035 #220)

### DIFF
--- a/src/js/pages/fatura.js
+++ b/src/js/pages/fatura.js
@@ -10,7 +10,7 @@
 // ============================================================
 
 import { onAuthChange, logout } from '../services/auth.js';
-import { buscarPerfil, buscarGrupo, ouvirContas, ouvirCategorias, ouvirDespesas, ouvirDespesasPorMesFatura, garantirContasPadrao } from '../services/database.js';
+import { buscarPerfil, buscarGrupo, ouvirContas, ouvirCategorias, ouvirDespesas, ouvirDespesasPorMesFatura, garantirContasPadrao, buscarPagamentosFaturaCartao } from '../services/database.js';
 import { formatarMoeda, formatarData, nomeMes, escHTML } from '../utils/formatters.js';
 import { recalcularScoreFatura } from '../utils/reconciliadorFatura.js';
 import { skeletonTableRows, skeletonChart, errorStateHTML, emptyStateHTML } from '../utils/skeletons.js';
@@ -633,7 +633,7 @@ function _toTs(data) {
  * Renderiza o painel de liquidação: mostra se o ciclo atual tem pagamentos
  * de fatura associados e o status de reconciliação.
  */
-function renderizarLiquidacao() {
+async function renderizarLiquidacao() {
   const container = document.getElementById('fat-liquidacao-content');
   if (!container) return;
 
@@ -642,19 +642,31 @@ function renderizarLiquidacao() {
     return;
   }
 
-  const mesFaturaStr = String(_ano) + '-' + String(_mes).padStart(2, '0');
+  container.innerHTML = '<p class="fat-empty-text">Carregando…</p>';
 
-  // Despesas reais (excluindo projeções) do ciclo desta fatura
+  // Despesas reais (excluindo projeções) do ciclo desta fatura — já em _despesas
   const despesasReais = _despesas.filter(d =>
     d.tipo === 'despesa' || d.tipo === 'projecao_paga'
   );
   const totalFatura = despesasReais.reduce((s, d) => s + (d.valor ?? 0), 0);
 
-  // Pagamentos de fatura registrados (tipo = 'pagamento_fatura' que referenciam este cartão)
-  // Nota: pagamentos bancários ficam na conta bancária, não no cartão —
-  // buscamos por statusReconciliacaoFatura e contaCartaoId ou pelo mes faturado
-  const pagamentos = _despesas.filter(d => d.tipo === 'pagamento_fatura'
-    && (d.mesFaturaQuitado === mesFaturaStr || d.contaCartaoId === _cartaoId));
+  // BUG-035: pagamento_fatura tem contaId = conta bancária (não o cartão), portanto
+  // _despesas nunca os inclui (filtro d.contaId !== _cartaoId em _merge()).
+  // Query dedicada por contaCartaoId garante que os pagamentos apareçam.
+  let candidatos = [];
+  try {
+    candidatos = await buscarPagamentosFaturaCartao(_grupoId, _cartaoId);
+  } catch (err) {
+    console.error('[fatura] Erro ao buscar pagamentos de fatura:', err);
+  }
+
+  // Janela temporal: ±2 meses do ciclo. Evita mostrar pagamentos de outros anos.
+  const janelainicio = new Date(_ano, _mes - 2, 1);
+  const janelaFim   = new Date(_ano, _mes + 2, 1);
+  const pagamentos  = candidatos.filter(p => {
+    const dt = p.data?.toDate?.() ?? (p.data instanceof Date ? p.data : new Date(p.data));
+    return !isNaN(dt?.getTime()) && dt >= janelainicio && dt <= janelaFim;
+  });
 
   if (pagamentos.length === 0) {
     const aviso = totalFatura > 0

--- a/src/js/services/database.js
+++ b/src/js/services/database.js
@@ -141,6 +141,21 @@ export async function atualizarDespesa(despesaId, dados) {
   return updateDoc(doc(db, 'despesas', despesaId), dados);
 }
 
+// RF-064: retorna pagamentos de fatura de um cartão específico.
+// pagamento_fatura tem contaId = conta bancária, não do cartão — query dedicada necessária.
+export async function buscarPagamentosFaturaCartao(grupoId, contaCartaoId) {
+  const q = query(
+    collection(db, 'despesas'),
+    where('grupoId', '==', grupoId),
+    where('tipo',    '==', 'pagamento_fatura'),
+    orderBy('data',  'asc'),
+  );
+  const snap = await getDocs(q);
+  return snap.docs
+    .map(d => ({ id: d.id, ...d.data() }))
+    .filter(d => d.contaCartaoId === contaCartaoId);
+}
+
 // BUG-022: retorna despesas pelo campo mesFatura (ciclo de faturamento).
 // Complementa ouvirDespesas (mês calendário) para cobrir transações com data fora do mês.
 export function ouvirDespesasPorMesFatura(grupoId, mesFatura, callback) {


### PR DESCRIPTION
## Root cause

`pagamento_fatura` entries are stored with `contaId = bankAccountId` (the bank account that made the debit), not the credit card ID. The `_merge()` function in `fatura.js` filters by `d.contaId !== _cartaoId`, so these entries were always excluded from `_despesas`. As a result, `renderizarLiquidacao()` always showed "Fatura em aberto" even when payments existed in Firestore.

## Fix

**`src/js/services/database.js`** — Added `buscarPagamentosFaturaCartao(grupoId, contaCartaoId)`:
- Queries `tipo === 'pagamento_fatura'` using the existing `(grupoId, tipo, data)` composite index
- Filters client-side by `contaCartaoId` (null-safe: entries without `contaCartaoId` are excluded)

**`src/js/pages/fatura.js`** — `renderizarLiquidacao()` converted to async:
- Shows `Carregando…` while fetching
- Calls the dedicated query instead of filtering from `_despesas`
- Applies ±2 month date window to avoid payments from unrelated cycles
- `_merge()` and the Todas/Projeções/Conjuntas tabs are unaffected

## Known limitation (pre-existing)

Payments where `contaCartaoId` could not be auto-inferred during import (card name not recognizable) remain invisible. This is a separate concern — the import pipeline review confirms this was already the case before this fix. A follow-up issue can address manual `contaCartaoId` assignment in the import UI.

## Testing

- 851/851 unit tests passing
- ux-reviewer subagent: **APPROVED** (PUX1–PUX6 all pass)
- import-pipeline-reviewer subagent: **APPROVED** (index verified, null-safety confirmed, no pipeline regression)

## Closes

Fixes #220 (BUG-035)

🤖 Generated with [Claude Code](https://claude.com/claude-code)